### PR TITLE
22: allowing to search stores by state and/or by fulfillment centers used by store

### DIFF
--- a/VirtoCommerce.StoreModule.Data/Services/StoreServiceImpl.cs
+++ b/VirtoCommerce.StoreModule.Data/Services/StoreServiceImpl.cs
@@ -44,7 +44,7 @@ namespace VirtoCommerce.StoreModule.Data.Services
 
         #region IStoreService Members
 
-        public Store[] GetByIds(string[] ids)
+        public virtual Store[] GetByIds(string[] ids)
         {
             var stores = new List<Store>();
 
@@ -99,12 +99,12 @@ namespace VirtoCommerce.StoreModule.Data.Services
             return result;
         }
 
-        public Store GetById(string id)
+        public virtual Store GetById(string id)
         {
             return GetByIds(new[] { id }).FirstOrDefault();
         }
 
-        public Store Create(Store store)
+        public virtual Store Create(Store store)
         {
             var pkMap = new PrimaryKeyResolvingMap();
 
@@ -132,7 +132,7 @@ namespace VirtoCommerce.StoreModule.Data.Services
             return retVal;
         }
 
-        public void Update(Store[] stores)
+        public virtual void Update(Store[] stores)
         {
             var pkMap = new PrimaryKeyResolvingMap();
 
@@ -163,7 +163,7 @@ namespace VirtoCommerce.StoreModule.Data.Services
             }
         }
 
-        public void Delete(string[] ids)
+        public virtual void Delete(string[] ids)
         {
             using (var repository = _repositoryFactory())
             {
@@ -187,20 +187,13 @@ namespace VirtoCommerce.StoreModule.Data.Services
             }
         }
 
-        public SearchResult SearchStores(SearchCriteria criteria)
+        public virtual SearchResult SearchStores(SearchCriteria criteria)
         {
             var retVal = new SearchResult();
             using (var repository = _repositoryFactory())
             {
-                var query = repository.Stores;
-                if (!string.IsNullOrEmpty(criteria.Keyword))
-                {
-                    query = query.Where(x => x.Name.Contains(criteria.Keyword) || x.Id.Contains(criteria.Keyword));
-                }
-                if (!criteria.StoreIds.IsNullOrEmpty())
-                {
-                    query = query.Where(x => criteria.StoreIds.Contains(x.Id));
-                }
+                var query = GetStoresQuery(repository, criteria);
+
                 var sortInfos = criteria.SortInfos;
                 if (sortInfos.IsNullOrEmpty())
                 {
@@ -226,7 +219,7 @@ namespace VirtoCommerce.StoreModule.Data.Services
         /// </summary>
         /// <param name="userId"></param>
         /// <returns></returns>
-        public IEnumerable<string> GetUserAllowedStoreIds(ApplicationUserExtended user)
+        public virtual IEnumerable<string> GetUserAllowedStoreIds(ApplicationUserExtended user)
         {
             if (user == null)
             {
@@ -250,7 +243,36 @@ namespace VirtoCommerce.StoreModule.Data.Services
             return retVal;
         }
 
-        private void ValidateStoreProperties(Store store)
+
+        protected virtual IQueryable<StoreEntity> GetStoresQuery(IStoreRepository repository, SearchCriteria criteria)
+        {
+            var query = repository.Stores;
+
+            if (!string.IsNullOrEmpty(criteria.Keyword))
+            {
+                query = query.Where(x => x.Name.Contains(criteria.Keyword) || x.Id.Contains(criteria.Keyword));
+            }
+
+            if (!criteria.StoreIds.IsNullOrEmpty())
+            {
+                query = query.Where(x => criteria.StoreIds.Contains(x.Id));
+            }
+
+            if (criteria.StoreStates?.Any() == true)
+            {
+                query = query.Where(x => criteria.StoreStates.Contains((StoreState)x.StoreState));
+            }
+
+            if (criteria.FulfillmentCenterIds?.Any() == true)
+            {
+                query = query.Where(x => criteria.FulfillmentCenterIds.Contains(x.FulfillmentCenterId) ||
+                                         x.FulfillmentCenters.Any(y => criteria.FulfillmentCenterIds.Contains(y.Id)));
+            }
+
+            return query;
+        }
+
+        protected virtual void ValidateStoreProperties(Store store)
         {
             if (store == null)
             {

--- a/VirtoCommerce.StoreModule.Data/Services/StoreServiceImpl.cs
+++ b/VirtoCommerce.StoreModule.Data/Services/StoreServiceImpl.cs
@@ -258,12 +258,12 @@ namespace VirtoCommerce.StoreModule.Data.Services
                 query = query.Where(x => criteria.StoreIds.Contains(x.Id));
             }
 
-            if (criteria.StoreStates?.Any() == true)
+            if (criteria.StoreStates.IsNullOrEmpty())
             {
                 query = query.Where(x => criteria.StoreStates.Contains((StoreState)x.StoreState));
             }
 
-            if (criteria.FulfillmentCenterIds?.Any() == true)
+            if (criteria.FulfillmentCenterIds.IsNullOrEmpty())
             {
                 query = query.Where(x => criteria.FulfillmentCenterIds.Contains(x.FulfillmentCenterId) ||
                                          x.FulfillmentCenters.Any(y => criteria.FulfillmentCenterIds.Contains(y.Id)));

--- a/VirtoCommerce.StoreModule.Data/Services/StoreServiceImpl.cs
+++ b/VirtoCommerce.StoreModule.Data/Services/StoreServiceImpl.cs
@@ -258,12 +258,12 @@ namespace VirtoCommerce.StoreModule.Data.Services
                 query = query.Where(x => criteria.StoreIds.Contains(x.Id));
             }
 
-            if (criteria.StoreStates.IsNullOrEmpty())
+            if (!criteria.StoreStates.IsNullOrEmpty())
             {
                 query = query.Where(x => criteria.StoreStates.Contains((StoreState)x.StoreState));
             }
 
-            if (criteria.FulfillmentCenterIds.IsNullOrEmpty())
+            if (!criteria.FulfillmentCenterIds.IsNullOrEmpty())
             {
                 query = query.Where(x => criteria.FulfillmentCenterIds.Contains(x.FulfillmentCenterId) ||
                                          x.FulfillmentCenters.Any(y => criteria.FulfillmentCenterIds.Contains(y.Id)));

--- a/VirtoCommerce.StoreModule.Data/VirtoCommerce.StoreModule.Data.csproj
+++ b/VirtoCommerce.StoreModule.Data/VirtoCommerce.StoreModule.Data.csproj
@@ -90,8 +90,8 @@
     <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.42.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.42\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.26.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.Platform.Data.2.13.26\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.42.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.Platform.Data.2.13.42\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/VirtoCommerce.StoreModule.Data/VirtoCommerce.StoreModule.Data.csproj
+++ b/VirtoCommerce.StoreModule.Data/VirtoCommerce.StoreModule.Data.csproj
@@ -84,11 +84,11 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="VirtoCommerce.Domain, Version=2.25.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.Domain.2.25.0\lib\net461\VirtoCommerce.Domain.dll</HintPath>
+    <Reference Include="VirtoCommerce.Domain, Version=2.25.25.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.Domain.2.25.25\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.26.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.26\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.42.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.42\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
     <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.26.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\VirtoCommerce.Platform.Data.2.13.26\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>

--- a/VirtoCommerce.StoreModule.Data/packages.config
+++ b/VirtoCommerce.StoreModule.Data/packages.config
@@ -11,7 +11,7 @@
   <package id="System.ComponentModel.Annotations" version="4.4.1" targetFramework="net461" />
   <package id="System.ComponentModel.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net451" />
-  <package id="VirtoCommerce.Domain" version="2.25.0" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.26" targetFramework="net461" />
+  <package id="VirtoCommerce.Domain" version="2.25.25" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.42" targetFramework="net461" />
   <package id="VirtoCommerce.Platform.Data" version="2.13.26" targetFramework="net461" />
 </packages>

--- a/VirtoCommerce.StoreModule.Data/packages.config
+++ b/VirtoCommerce.StoreModule.Data/packages.config
@@ -13,5 +13,5 @@
   <package id="valueinjecter" version="2.3.3" targetFramework="net451" />
   <package id="VirtoCommerce.Domain" version="2.25.25" targetFramework="net461" />
   <package id="VirtoCommerce.Platform.Core" version="2.13.42" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Data" version="2.13.26" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Data" version="2.13.42" targetFramework="net461" />
 </packages>

--- a/VirtoCommerce.StoreModule.Test/VirtoCommerce.StoreModule.Test.csproj
+++ b/VirtoCommerce.StoreModule.Test/VirtoCommerce.StoreModule.Test.csproj
@@ -82,8 +82,8 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.IO.Compression" />
-    <Reference Include="VirtoCommerce.CoreModule.Data, Version=2.25.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.CoreModule.Data.2.25.0\lib\net461\VirtoCommerce.CoreModule.Data.dll</HintPath>
+    <Reference Include="VirtoCommerce.CoreModule.Data, Version=2.25.25.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.CoreModule.Data.2.25.25\lib\net461\VirtoCommerce.CoreModule.Data.dll</HintPath>
     </Reference>
     <Reference Include="VirtoCommerce.Domain, Version=2.25.25.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\VirtoCommerce.Domain.2.25.25\lib\net461\VirtoCommerce.Domain.dll</HintPath>

--- a/VirtoCommerce.StoreModule.Test/VirtoCommerce.StoreModule.Test.csproj
+++ b/VirtoCommerce.StoreModule.Test/VirtoCommerce.StoreModule.Test.csproj
@@ -91,8 +91,8 @@
     <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.42.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.42\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.26.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.Platform.Data.2.13.26\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.42.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.Platform.Data.2.13.42\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>

--- a/VirtoCommerce.StoreModule.Test/VirtoCommerce.StoreModule.Test.csproj
+++ b/VirtoCommerce.StoreModule.Test/VirtoCommerce.StoreModule.Test.csproj
@@ -85,11 +85,11 @@
     <Reference Include="VirtoCommerce.CoreModule.Data, Version=2.25.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\VirtoCommerce.CoreModule.Data.2.25.0\lib\net461\VirtoCommerce.CoreModule.Data.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Domain, Version=2.25.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.Domain.2.25.0\lib\net461\VirtoCommerce.Domain.dll</HintPath>
+    <Reference Include="VirtoCommerce.Domain, Version=2.25.25.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.Domain.2.25.25\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.26.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.26\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.42.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.42\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
     <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.26.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\VirtoCommerce.Platform.Data.2.13.26\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>

--- a/VirtoCommerce.StoreModule.Test/packages.config
+++ b/VirtoCommerce.StoreModule.Test/packages.config
@@ -17,7 +17,7 @@
   <package id="VirtoCommerce.CoreModule.Data" version="2.25.0" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.25" targetFramework="net461" />
   <package id="VirtoCommerce.Platform.Core" version="2.13.42" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Data" version="2.13.26" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Data" version="2.13.42" targetFramework="net461" />
   <package id="xunit" version="2.3.1" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
   <package id="xunit.analyzers" version="0.7.0" targetFramework="net461" />

--- a/VirtoCommerce.StoreModule.Test/packages.config
+++ b/VirtoCommerce.StoreModule.Test/packages.config
@@ -14,7 +14,7 @@
   <package id="System.ComponentModel.Annotations" version="4.4.1" targetFramework="net461" />
   <package id="System.ComponentModel.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net451" />
-  <package id="VirtoCommerce.CoreModule.Data" version="2.25.0" targetFramework="net461" />
+  <package id="VirtoCommerce.CoreModule.Data" version="2.25.25" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.25" targetFramework="net461" />
   <package id="VirtoCommerce.Platform.Core" version="2.13.42" targetFramework="net461" />
   <package id="VirtoCommerce.Platform.Data" version="2.13.42" targetFramework="net461" />

--- a/VirtoCommerce.StoreModule.Test/packages.config
+++ b/VirtoCommerce.StoreModule.Test/packages.config
@@ -15,8 +15,8 @@
   <package id="System.ComponentModel.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net451" />
   <package id="VirtoCommerce.CoreModule.Data" version="2.25.0" targetFramework="net461" />
-  <package id="VirtoCommerce.Domain" version="2.25.0" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.26" targetFramework="net461" />
+  <package id="VirtoCommerce.Domain" version="2.25.25" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.42" targetFramework="net461" />
   <package id="VirtoCommerce.Platform.Data" version="2.13.26" targetFramework="net461" />
   <package id="xunit" version="2.3.1" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />

--- a/VirtoCommerce.StoreModule.Web/VirtoCommerce.StoreModule.Web.csproj
+++ b/VirtoCommerce.StoreModule.Web/VirtoCommerce.StoreModule.Web.csproj
@@ -120,11 +120,11 @@
     <Reference Include="System.Web.Services" />
     <Reference Include="System.EnterpriseServices" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="VirtoCommerce.Domain, Version=2.25.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.Domain.2.25.0\lib\net461\VirtoCommerce.Domain.dll</HintPath>
+    <Reference Include="VirtoCommerce.Domain, Version=2.25.25.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.Domain.2.25.25\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.26.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.26\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.42.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.42\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
     <Reference Include="VirtoCommerce.Platform.Core.Web, Version=2.13.26.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\VirtoCommerce.Platform.Core.Web.2.13.26\lib\net461\VirtoCommerce.Platform.Core.Web.dll</HintPath>

--- a/VirtoCommerce.StoreModule.Web/VirtoCommerce.StoreModule.Web.csproj
+++ b/VirtoCommerce.StoreModule.Web/VirtoCommerce.StoreModule.Web.csproj
@@ -99,8 +99,8 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.4\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web.DynamicData" />
@@ -112,8 +112,8 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Web.Http, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.4\lib\net45\System.Web.Http.dll</HintPath>
+    <Reference Include="System.Web.Http, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.7\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
@@ -126,11 +126,11 @@
     <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.42.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.42\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core.Web, Version=2.13.26.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.Platform.Core.Web.2.13.26\lib\net461\VirtoCommerce.Platform.Core.Web.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core.Web, Version=2.13.42.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.Platform.Core.Web.2.13.42\lib\net461\VirtoCommerce.Platform.Core.Web.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.26.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.Platform.Data.2.13.26\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.42.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.Platform.Data.2.13.42\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/VirtoCommerce.StoreModule.Web/module.manifest
+++ b/VirtoCommerce.StoreModule.Web/module.manifest
@@ -2,7 +2,7 @@
 <module>
     <id>VirtoCommerce.Store</id>
     <version>2.13.8</version>
-    <platformVersion>2.13.26</platformVersion>
+    <platformVersion>2.13.42</platformVersion>
     <dependencies>
         <dependency id="VirtoCommerce.Core" version="2.25.25" />
         <dependency id="VirtoCommerce.Inventory" version="2.13.0" />

--- a/VirtoCommerce.StoreModule.Web/module.manifest
+++ b/VirtoCommerce.StoreModule.Web/module.manifest
@@ -4,7 +4,7 @@
     <version>2.13.8</version>
     <platformVersion>2.13.26</platformVersion>
     <dependencies>
-        <dependency id="VirtoCommerce.Core" version="2.25.0" />
+        <dependency id="VirtoCommerce.Core" version="2.25.25" />
         <dependency id="VirtoCommerce.Inventory" version="2.13.0" />
         <dependency id="VirtoCommerce.Catalog" version="2.11.0" />
     </dependencies>

--- a/VirtoCommerce.StoreModule.Web/packages.config
+++ b/VirtoCommerce.StoreModule.Web/packages.config
@@ -12,9 +12,9 @@
   <package id="StackExchange.Redis" version="1.2.6" targetFramework="net461" />
   <package id="Unity" version="4.0.1" targetFramework="net451" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net451" />
-  <package id="VirtoCommerce.Domain" version="2.25.0" targetFramework="net461" />
+  <package id="VirtoCommerce.Domain" version="2.25.25" targetFramework="net461" />
   <package id="VirtoCommerce.Module" version="0.17.0" targetFramework="net461" developmentDependency="true" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.26" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.42" targetFramework="net461" />
   <package id="VirtoCommerce.Platform.Core.Web" version="2.13.26" targetFramework="net461" />
   <package id="VirtoCommerce.Platform.Data" version="2.13.26" targetFramework="net461" />
 </packages>

--- a/VirtoCommerce.StoreModule.Web/packages.config
+++ b/VirtoCommerce.StoreModule.Web/packages.config
@@ -5,8 +5,8 @@
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net451" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net461" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.4" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net461" />
   <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net461" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
   <package id="StackExchange.Redis" version="1.2.6" targetFramework="net461" />
@@ -15,6 +15,6 @@
   <package id="VirtoCommerce.Domain" version="2.25.25" targetFramework="net461" />
   <package id="VirtoCommerce.Module" version="0.17.0" targetFramework="net461" developmentDependency="true" />
   <package id="VirtoCommerce.Platform.Core" version="2.13.42" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core.Web" version="2.13.26" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Data" version="2.13.26" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core.Web" version="2.13.42" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Data" version="2.13.42" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This PR is part of #22. It does following changes:
* Extends store search in `StoreServiceImpl` by using new fields from `SearchCriteria`. This will allow to filter stores:
    * by store state;
    * by fulfillment centers used by store (either as main or additional FFC).
* Makes all of `StoreServiceImpl` methods virtual and extracts building store search query to a separate virtual method. This way, `StoreServiceImpl` will be easier to extend.

Please note that this PR uses models added in VirtoCommerce/vc-module-core#125. I did not update NuGet and module references, since these changes are not released yet; however, this will be necessary for successfully building this module.