### PR TITLE
22: fixing incorrect condition in store search by used FFC

### DIFF
--- a/VirtoCommerce.StoreModule.Data/Services/StoreServiceImpl.cs
+++ b/VirtoCommerce.StoreModule.Data/Services/StoreServiceImpl.cs
@@ -266,7 +266,7 @@ namespace VirtoCommerce.StoreModule.Data.Services
             if (!criteria.FulfillmentCenterIds.IsNullOrEmpty())
             {
                 query = query.Where(x => criteria.FulfillmentCenterIds.Contains(x.FulfillmentCenterId) ||
-                                         x.FulfillmentCenters.Any(y => criteria.FulfillmentCenterIds.Contains(y.Id)));
+                                         x.FulfillmentCenters.Any(y => criteria.FulfillmentCenterIds.Contains(y.FulfillmentCenterId)));
             }
 
             return query;


### PR DESCRIPTION
In #23, I've added a code that filters stores by FFCs used by these stores (either as main FFC or in available FFCs). But turns out that I've made a [silly mistake](https://github.com/VirtoCommerce/vc-module-store/pull/23/files#diff-81a2edb67759e1be2a29631dc2d28d69R269) there, When looking for stores by their additional FFCs, the code compares FFC IDs from search criteria with the ID of the store-FFC relation itself, which is wrong - it should check the `FulfillmenCenterId` property of the relation instead. So, this PR fixes that mistake.