### PR TITLE
VP-4038: Fix error after selecting changed store state

### DIFF
--- a/src/VirtoCommerce.StoreModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.StoreModule.Core/ModuleConstants.cs
@@ -32,7 +32,8 @@ namespace VirtoCommerce.StoreModule.Core
                     GroupName = "Store|General",
                     IsDictionary = true,
                     DefaultValue = "Open",
-                    AllowedValues = new[] { "Open", "Closed", "RestrictedAccess" }
+                    AllowedValues = new[] { "Open", "Closed", "RestrictedAccess" },
+                    IsHidden = true
                 };
 
                 public static SettingDescriptor TaxCalculationEnabled = new SettingDescriptor

--- a/src/VirtoCommerce.StoreModule.Core/VirtoCommerce.StoreModule.Core.csproj
+++ b/src/VirtoCommerce.StoreModule.Core/VirtoCommerce.StoreModule.Core.csproj
@@ -8,7 +8,7 @@
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.0.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.22.0" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.StoreModule.Core/VirtoCommerce.StoreModule.Core.csproj
+++ b/src/VirtoCommerce.StoreModule.Core/VirtoCommerce.StoreModule.Core.csproj
@@ -8,7 +8,7 @@
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.22.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.13.0" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.StoreModule.Data/VirtoCommerce.StoreModule.Data.csproj
+++ b/src/VirtoCommerce.StoreModule.Data/VirtoCommerce.StoreModule.Data.csproj
@@ -22,9 +22,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.22.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.22.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.22.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.13.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.13.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.13.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.StoreModule.Core\VirtoCommerce.StoreModule.Core.csproj" />

--- a/src/VirtoCommerce.StoreModule.Data/VirtoCommerce.StoreModule.Data.csproj
+++ b/src/VirtoCommerce.StoreModule.Data/VirtoCommerce.StoreModule.Data.csproj
@@ -22,9 +22,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.0.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.0.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.0.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.22.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.22.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.22.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.StoreModule.Core\VirtoCommerce.StoreModule.Core.csproj" />

--- a/src/VirtoCommerce.StoreModule.Web/Scripts/blades/store-detail.tpl.html
+++ b/src/VirtoCommerce.StoreModule.Web/Scripts/blades/store-detail.tpl.html
@@ -36,7 +36,7 @@
                     </div>
                     <div class="column">
                         <div class="form-group">
-                            <label class="form-label">{{ 'stores.blades.store-detail.labels.state' | translate }} <a href="" ng-click="openStatesDictionarySettingManagement()" class="form-edit" va-permission="platform:setting:update"><i class="form-ico fa fa-pencil"></i></a></label>
+                            <label class="form-label">{{ 'stores.blades.store-detail.labels.state' | translate }} </label>
                             <div class="form-input">
                                 <ui-select ng-model="blade.currentEntity.storeState" required>
                                     <ui-select-match placeholder="{{ 'stores.blades.store-detail.placeholders.state' | translate }}">{{$select.selected}}</ui-select-match>

--- a/src/VirtoCommerce.StoreModule.Web/VirtoCommerce.StoreModule.Web.csproj
+++ b/src/VirtoCommerce.StoreModule.Web/VirtoCommerce.StoreModule.Web.csproj
@@ -20,10 +20,10 @@
     <None Remove="node_modules\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.22.0" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />
   </ItemGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.13.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.StoreModule.Core\VirtoCommerce.StoreModule.Core.csproj" />

--- a/src/VirtoCommerce.StoreModule.Web/VirtoCommerce.StoreModule.Web.csproj
+++ b/src/VirtoCommerce.StoreModule.Web/VirtoCommerce.StoreModule.Web.csproj
@@ -20,7 +20,7 @@
     <None Remove="node_modules\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.0.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.22.0" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />

--- a/src/VirtoCommerce.StoreModule.Web/module.manifest
+++ b/src/VirtoCommerce.StoreModule.Web/module.manifest
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <id>VirtoCommerce.Store</id>
   <version>3.5.0</version>
   <version-tag />
-  <platformVersion>3.0.0</platformVersion>
+  <platformVersion>3.22.0</platformVersion>
   <title>Store module</title>
   <description>Multi store management with individual store settings</description>
   <authors>

--- a/src/VirtoCommerce.StoreModule.Web/module.manifest
+++ b/src/VirtoCommerce.StoreModule.Web/module.manifest
@@ -3,7 +3,7 @@
   <id>VirtoCommerce.Store</id>
   <version>3.5.0</version>
   <version-tag />
-  <platformVersion>3.22.0</platformVersion>
+  <platformVersion>3.13.0</platformVersion>
   <title>Store module</title>
   <description>Multi store management with individual store settings</description>
   <authors>


### PR DESCRIPTION
### Problem
There is 500 error after selecting changed store state 

### Solution
Make States readonly.

###Proposed of changes
Update platform dependency version
Set "State" setting hidden
Set "State" option on store detail blade read only.

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
