### PR TITLE
VP-5672: Infinite scroll in catalog drop down fields

### DIFF
--- a/src/VirtoCommerce.StoreModule.Web/Scripts/blades/store-detail.js
+++ b/src/VirtoCommerce.StoreModule.Web/Scripts/blades/store-detail.js
@@ -2,21 +2,25 @@ angular.module('virtoCommerce.storeModule')
 .controller('virtoCommerce.storeModule.storeDetailController', ['$scope', 'platformWebApp.bladeNavigationService', 'virtoCommerce.storeModule.stores', 'virtoCommerce.storeModule.catalogs', 'platformWebApp.settings', 'platformWebApp.settings.helper', 'platformWebApp.dialogService', 'virtoCommerce.coreModule.currency.currencyUtils',
     function ($scope, bladeNavigationService, stores, catalogs, settings, settingsHelper, dialogService, currencyUtils) {
         var blade = $scope.blade;
+        $scope.pageSize = 20;
         blade.updatePermission = 'store:update';
         blade.subtitle = 'stores.blades.store-detail.subtitle';
 
         blade.refresh = function (parentRefresh) {
             blade.isLoading = true;
-            stores.get({ id: blade.currentEntityId }, function (data) {
+            stores.get({ id: blade.currentEntityId }, (data) => {
                 initializeBlade(data);
                 if (parentRefresh) {
                     blade.parentBlade.refresh();
                 }
-            },
-            function (error) { bladeNavigationService.setError('Error ' + error.status, blade); });
+            })
         }
 
+
         function initializeBlade(data) {
+
+            getCatalog(data.catalog); 
+
             data.additionalLanguages = _.without(data.languages, data.defaultLanguage);
             data.additionalCurrencies = _.without(data.currencies, data.defaultCurrency);
 
@@ -45,6 +49,13 @@ angular.module('virtoCommerce.storeModule')
             if (blade.currentEntity.scopes && angular.isArray(blade.currentEntity.scopes)) {
                 blade.scopes = blade.currentEntity.scopes;
             }
+        }
+
+        async function getCatalog(catalogId) {
+            $scope.catalogs = [];
+
+            let catalog = await catalogs.get({ id: catalogId }).$promise;
+            $scope.catalogs.push(catalog)
         }
 
         function isDirty() {
@@ -91,6 +102,25 @@ angular.module('virtoCommerce.storeModule')
                 }
             }
             dialogService.showConfirmationDialog(dialog);
+        }
+
+        $scope.fetchCatalogs = ($select) => {
+            $select.page = 0;
+            $scope.catalogs = [];
+            $scope.fetchNextCatalogs($select);
+        }
+    
+        $scope.fetchNextCatalogs = ($select) => {
+            let criteria = {
+                SearchPhrase: $select.search,
+                take: $scope.pageSize,
+                skip: $select.page * $scope.pageSize
+            }
+
+            catalogs.search(criteria, (data) => {
+                $scope.catalogs = $scope.catalogs.concat(data.results);
+                $select.page++;
+            });
         }
 
         $scope.setForm = function (form) { $scope.formScope = form; };
@@ -165,7 +195,7 @@ angular.module('virtoCommerce.storeModule')
         });
 
         blade.refresh();
-        $scope.catalogs = catalogs.getCatalogs();
+        
         $scope.storeStates = settings.getValues({ id: 'Stores.States' });
         $scope.languages = settings.getValues({ id: 'VirtoCommerce.Core.General.Languages' });
         $scope.allStores = stores.query();

--- a/src/VirtoCommerce.StoreModule.Web/Scripts/blades/store-detail.js
+++ b/src/VirtoCommerce.StoreModule.Web/Scripts/blades/store-detail.js
@@ -3,8 +3,10 @@ angular.module('virtoCommerce.storeModule')
     function ($scope, bladeNavigationService, stores, catalogs, settings, settingsHelper, dialogService, currencyUtils) {
         var blade = $scope.blade;
         $scope.pageSize = 20;
+        $scope.catalogs = [];
         blade.updatePermission = 'store:update';
         blade.subtitle = 'stores.blades.store-detail.subtitle';
+        blade.catalogId = undefined;
 
         blade.refresh = function (parentRefresh) {
             blade.isLoading = true;
@@ -16,15 +18,12 @@ angular.module('virtoCommerce.storeModule')
             })
         }
 
-
         function initializeBlade(data) {
-
-            getCatalog(data.catalog); 
-
             data.additionalLanguages = _.without(data.languages, data.defaultLanguage);
             data.additionalCurrencies = _.without(data.currencies, data.defaultCurrency);
 
             blade.currentEntityId = data.id;
+            blade.catalogId = data.catalog;
             blade.title = data.name;
 
             settingsHelper.fixValues(data.settings);
@@ -49,13 +48,6 @@ angular.module('virtoCommerce.storeModule')
             if (blade.currentEntity.scopes && angular.isArray(blade.currentEntity.scopes)) {
                 blade.scopes = blade.currentEntity.scopes;
             }
-        }
-
-        async function getCatalog(catalogId) {
-            $scope.catalogs = [];
-
-            let catalog = await catalogs.get({ id: catalogId }).$promise;
-            $scope.catalogs.push(catalog)
         }
 
         function isDirty() {
@@ -104,9 +96,15 @@ angular.module('virtoCommerce.storeModule')
             dialogService.showConfirmationDialog(dialog);
         }
 
-        $scope.fetchCatalogs = ($select) => {
+        $scope.fetchCatalogs = async ($select) => {
             $select.page = 0;
             $scope.catalogs = [];
+
+            if(blade.catalogId) {
+                let catalog = await catalogs.get({ id: blade.catalogId }).$promise; 
+                $scope.catalogs.push(catalog);
+            }
+
             $scope.fetchNextCatalogs($select);
         }
     

--- a/src/VirtoCommerce.StoreModule.Web/Scripts/blades/store-detail.tpl.html
+++ b/src/VirtoCommerce.StoreModule.Web/Scripts/blades/store-detail.tpl.html
@@ -27,7 +27,7 @@
                             <div class="form-input">
                                 <ui-select ng-model="blade.currentEntity.catalog" required>
                                     <ui-select-match placeholder="{{ 'stores.blades.store-detail.placeholders.catalog' | translate }}">{{$select.selected.name}}</ui-select-match>
-                                    <ui-select-choices repeat="x.id as x in catalogs | filter: { name: $select.search }">
+                                    <ui-select-choices repeat="x.id as x in catalogs | filter: { name: $select.search }" refresh="fetchCatalogs($select)" when-scrolled="fetchNextCatalogs($select)">
                                         <span ng-bind-html="x.name | highlight: $select.search"></span>
                                     </ui-select-choices>
                                 </ui-select>

--- a/src/VirtoCommerce.StoreModule.Web/Scripts/blades/store-detail.tpl.html
+++ b/src/VirtoCommerce.StoreModule.Web/Scripts/blades/store-detail.tpl.html
@@ -25,10 +25,10 @@
                         <div class="form-group">
                             <label class="form-label">{{ 'stores.blades.store-detail.labels.catalog' | translate }}</label>
                             <div class="form-input">
-                                <ui-select ng-model="blade.currentEntity.catalog" required>
-                                    <ui-select-match placeholder="{{ 'stores.blades.store-detail.placeholders.catalog' | translate }}">{{$select.selected.name}}</ui-select-match>
+                                <ui-select ng-model="blade.currentEntity.catalog" required ng-class="{disabled: catalogs.length === 0}">
+                                    <ui-select-match placeholder="{{ 'stores.blades.store-detail.placeholders.catalog' | translate }}">{{catalogs.length > 0 ? $select.selected.name : 'Loading...'}}</ui-select-match>
                                     <ui-select-choices repeat="x.id as x in catalogs | filter: { name: $select.search }" refresh="fetchCatalogs($select)" when-scrolled="fetchNextCatalogs($select)">
-                                        <span ng-bind-html="x.name | highlight: $select.search"></span>
+                                        <span ng-show = 'catalogs.length > 0' ng-bind-html="x.name | highlight: $select.search"></span>
                                     </ui-select-choices>
                                 </ui-select>
                             </div>

--- a/src/VirtoCommerce.StoreModule.Web/Scripts/resources/catalogs.js
+++ b/src/VirtoCommerce.StoreModule.Web/Scripts/resources/catalogs.js
@@ -1,6 +1,8 @@
 angular.module('virtoCommerce.storeModule')
 .factory('virtoCommerce.storeModule.catalogs', ['$resource', function ($resource) {
-    return $resource('api/catalog/catalogs/:id', { id: '@Id' }, {      
-        getCatalogs: { method: 'GET', isArray: true }       
+    return $resource('api/catalog/catalogs/:id', { id: '@Id' }, {
+        get: { method: 'GET' },
+        getCatalogs: { method: 'GET', isArray: true },
+        search: { method: 'POST', url: 'api/catalog/catalogs/search'},
     });
 }]);


### PR DESCRIPTION
### Problem
VP-5672 Only first 19 related entities is loaded in drop down fields

### Solution
Use infinite scroll for catalog dropdown

### Proposed of changes
Describe the technical details of realization provided by you.

### Additional context (optional)
Add any other context or screenshots about the feature request here.

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
