### PR TITLE
PT-3923: StoreIds declared as obsolete in StoreSearchCriteria

### DIFF
--- a/src/VirtoCommerce.StoreModule.Core/Model/Search/StoreSearchCriteria.cs
+++ b/src/VirtoCommerce.StoreModule.Core/Model/Search/StoreSearchCriteria.cs
@@ -1,10 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.StoreModule.Core.Model.Search
 {
     public class StoreSearchCriteria : SearchCriteriaBase
     {
-        public string[] StoreIds { get; set; }
+        [Obsolete("Please use ObjectIds property to filter by store ids")]
+        public string[] StoreIds
+        {
+            get
+            {
+#pragma warning disable S2365 
+                return ObjectIds.ToArray();
+#pragma warning restore S2365
+            }
+            set
+            {
+                ObjectIds = new List<string>(value);
+            }
+        }
+
         public StoreState[] StoreStates { get; set; }
         public string[] FulfillmentCenterIds { get; set; }
     }

--- a/src/VirtoCommerce.StoreModule.Core/Model/Search/StoreSearchCriteria.cs
+++ b/src/VirtoCommerce.StoreModule.Core/Model/Search/StoreSearchCriteria.cs
@@ -13,7 +13,7 @@ namespace VirtoCommerce.StoreModule.Core.Model.Search
             get
             {
 #pragma warning disable S2365 
-                return ObjectIds.ToArray();
+                return ObjectIds?.ToArray() ?? Array.Empty<string>();
 #pragma warning restore S2365
             }
             set

--- a/src/VirtoCommerce.StoreModule.Data/Services/StoreSearchService.cs
+++ b/src/VirtoCommerce.StoreModule.Data/Services/StoreSearchService.cs
@@ -29,11 +29,7 @@ namespace VirtoCommerce.StoreModule.Data.Services
             {
                 query = query.Where(x => x.Name.Contains(criteria.Keyword) || x.Id.Contains(criteria.Keyword));
             }
-            if (!criteria.StoreIds.IsNullOrEmpty())
-            {
-                query = query.Where(x => criteria.StoreIds.Contains(x.Id));
-            }
-            else if (!criteria.ObjectIds.IsNullOrEmpty())
+            if (!criteria.ObjectIds.IsNullOrEmpty())
             {
                 query = query.Where(x => criteria.ObjectIds.Contains(x.Id));
             }

--- a/src/VirtoCommerce.StoreModule.Web/Authorization/StoreAuthorizationHandler.cs
+++ b/src/VirtoCommerce.StoreModule.Web/Authorization/StoreAuthorizationHandler.cs
@@ -31,7 +31,7 @@ namespace VirtoCommerce.StoreModule.Web.Authorization
                     var allowedStoreIds = storeSelectedScopes.Select(x => x.StoreId).Distinct().ToArray();
                     if (context.Resource is StoreSearchCriteria criteria)
                     {
-                        criteria.StoreIds = allowedStoreIds;
+                        criteria.ObjectIds = allowedStoreIds;
                         context.Succeed(requirement);
                     }
                     if (context.Resource is Store store && allowedStoreIds.Contains(store.Id))

--- a/src/VirtoCommerce.StoreModule.Web/Controllers/Api/StoreModuleController.cs
+++ b/src/VirtoCommerce.StoreModule.Web/Controllers/Api/StoreModuleController.cs
@@ -107,7 +107,7 @@ namespace VirtoCommerce.StoreModule.Web.Controllers.Api
             {
                 Skip = 0,
                 Take = 1,
-                StoreIds = new[] { id }
+                ObjectIds = new[] { id }
             };
             var authorizationResult = await _authorizationService.AuthorizeAsync(User, criteria, new StoreAuthorizationRequirement(ModuleConstants.Security.Permissions.Read));
             if (!authorizationResult.Succeeded)

--- a/src/VirtoCommerce.StoreModule.Web/Scripts/directives/vaStoreSelector.js
+++ b/src/VirtoCommerce.StoreModule.Web/Scripts/directives/vaStoreSelector.js
@@ -43,7 +43,7 @@ angular.module('virtoCommerce.storeModule')
 
                     if ($scope.isNoChoices && _.any(storeIds)) {
                         stores.search({
-                            storeIds: storeIds,
+                            objectIds: storeIds,
                             take: storeIds.length,
                             responseGroup: 'none'
                         }, (data) => {


### PR DESCRIPTION
## Description
StoreIds declared as obsolete in StoreSearchCriteria. Add support for basic search criteria property ObjectIds.
## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/PT-3923
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Store_3.207.0-pr-107.zip
