### PR TITLE
VCST-2113: Add max length client-side validation for email input fields.

### DIFF
--- a/src/VirtoCommerce.StoreModule.Web/Scripts/blades/store-advanced.tpl.html
+++ b/src/VirtoCommerce.StoreModule.Web/Scripts/blades/store-advanced.tpl.html
@@ -1,83 +1,83 @@
 <div class="blade-static __bottom" ng-include="'$(Platform)/Scripts/common/templates/ok-cancel.tpl.html'"></div>
 <div class="blade-content __medium-wide">
-    <div class="blade-inner">
-        <div class="inner-block">
-            <form class="form" name="detailForm">
-		<fieldset>
-                <div ng-init="setForm(detailForm)">
-                    <label class="form-label">{{ 'stores.blades.store-advanced.labels.description' | translate }}</label>
-                    <div class="form-input">
-                        <textarea class="form-control" cols="30" rows="2" ng-model="blade.currentEntity.description" placeholder="{{ 'stores.blades.store-advanced.placeholders.description' | translate }}"></textarea>
-                    </div>
+  <div class="blade-inner">
+    <div class="inner-block">
+      <form class="form" name="detailForm">
+        <fieldset>
+          <div ng-init="setForm(detailForm)">
+            <label class="form-label">{{ 'stores.blades.store-advanced.labels.description' | translate }}</label>
+            <div class="form-input">
+              <textarea class="form-control" cols="30" rows="2" ng-model="blade.currentEntity.description" placeholder="{{ 'stores.blades.store-advanced.placeholders.description' | translate }}"></textarea>
+            </div>
+          </div>
+          <div class="form-group clearfix">
+            <legend>{{ 'stores.blades.store-advanced.labels.store-regional-settings' | translate }}</legend>
+            <div class="column">
+              <div class="form-group">
+                <label class="form-label">{{ 'stores.blades.store-advanced.labels.store-country' | translate }}</label>
+                <div class="form-input">
+                  <ui-select ng-model="blade.currentEntity.country">
+                    <ui-select-match placeholder="{{ 'stores.blades.store-advanced.placeholders.store-country' | translate }}">{{$select.selected.displayName}}</ui-select-match>
+                    <ui-select-choices repeat="x.id as x in countries | filter: { displayName: $select.search }">
+                      <span ng-bind-html="x.displayName | highlight: $select.search"></span>
+                    </ui-select-choices>
+                  </ui-select>
                 </div>
-                <div class="form-group clearfix">
-		<legend>{{ 'stores.blades.store-advanced.labels.store-regional-settings' | translate }}</legend>
-                    <div class="column">
-                        <div class="form-group">
-                            <label class="form-label">{{ 'stores.blades.store-advanced.labels.store-country' | translate }}</label>
-                            <div class="form-input">
-                                <ui-select ng-model="blade.currentEntity.country">
-                                    <ui-select-match placeholder="{{ 'stores.blades.store-advanced.placeholders.store-country' | translate }}">{{$select.selected.displayName}}</ui-select-match>
-                                    <ui-select-choices repeat="x.id as x in countries | filter: { displayName: $select.search }">
-                                        <span ng-bind-html="x.displayName | highlight: $select.search"></span>
-                                    </ui-select-choices>
-                                </ui-select>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="column">
-                        <div class="form-group">
-                            <label class="form-label">{{ 'stores.blades.store-advanced.labels.store-region' | translate }}</label>
-                            <div class="form-input">
-                                <input ng-model="blade.currentEntity.region" placeholder="{{ 'stores.blades.store-advanced.placeholders.store-region' | translate }}" />
-                            </div>
-                        </div>
-                    </div>
+              </div>
+            </div>
+            <div class="column">
+              <div class="form-group">
+                <label class="form-label">{{ 'stores.blades.store-advanced.labels.store-region' | translate }}</label>
+                <div class="form-input">
+                  <input ng-model="blade.currentEntity.region" placeholder="{{ 'stores.blades.store-advanced.placeholders.store-region' | translate }}" />
                 </div>
-                <div class="form-group clearfix">
-                    <label class="form-label">{{ 'stores.blades.store-advanced.labels.operational-timezone' | translate }}</label>
-                    <div class="form-input">
-                        <ui-select ng-model="blade.currentEntity.timeZone">
-                            <ui-select-match placeholder="{{ 'stores.blades.store-advanced.placeholders.operational-timezone' | translate }}">{{$select.selected.name}}</ui-select-match>
-                            <ui-select-choices repeat="x.id as x in timeZones | filter: { name: $select.search }">
-                                <span ng-bind-html="x.name | highlight: $select.search"></span>
-                            </ui-select-choices>
-                        </ui-select>
-                    </div>
+              </div>
+            </div>
+          </div>
+          <div class="form-group clearfix">
+            <label class="form-label">{{ 'stores.blades.store-advanced.labels.operational-timezone' | translate }}</label>
+            <div class="form-input">
+              <ui-select ng-model="blade.currentEntity.timeZone">
+                <ui-select-match placeholder="{{ 'stores.blades.store-advanced.placeholders.operational-timezone' | translate }}">{{$select.selected.name}}</ui-select-match>
+                <ui-select-choices repeat="x.id as x in timeZones | filter: { name: $select.search }">
+                  <span ng-bind-html="x.name | highlight: $select.search"></span>
+                </ui-select-choices>
+              </ui-select>
+            </div>
+          </div>
+          <div class="form-group clearfix">
+            <legend>{{ 'stores.blades.store-advanced.labels.store-email-settings' | translate }}</legend>
+            <div class="column">
+              <div class="form-group">
+                <label class="form-label">{{ 'stores.blades.store-advanced.labels.store-email-name' | translate }}</label>
+                <div class="form-input">
+                  <input ng-model="blade.currentEntity.emailName" ng-pattern="/^(?!.*[*|\x22:<>[\]{}`%';@&$])/" ng-maxlength="256" placeholder="{{ 'stores.blades.store-advanced.placeholders.store-email-name' | translate }}">
                 </div>
-                <div class="form-group clearfix">
-		<legend>{{ 'stores.blades.store-advanced.labels.store-email-settings' | translate }}</legend>
-                    <div class="column">
-                        <div class="form-group">
-                            <label class="form-label">{{ 'stores.blades.store-advanced.labels.store-email-name' | translate }}</label>
-                            <div class="form-input">
-                                <input ng-model="blade.currentEntity.emailName" ng-pattern="/^(?!.*[*|\x22:<>[\]{}`%';@&$])/" placeholder="{{ 'stores.blades.store-advanced.placeholders.store-email-name' | translate }}">
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label">{{ 'stores.blades.store-advanced.labels.store-admin-email-name' | translate }}</label>
-                            <div class="form-input">
-                                <input ng-model="blade.currentEntity.adminEmailName" ng-pattern="/^(?!.*[*|\x22:<>[\]{}`%';@&$])/" placeholder="{{ 'stores.blades.store-advanced.placeholders.store-admin-email-name' | translate }}">
-                            </div>
-                        </div>
-                    </div>
-                    <div class="column">
-                        <div class="form-group">
-                            <label class="form-label">{{ 'stores.blades.store-advanced.labels.store-email' | translate }}</label>
-                            <div class="form-input">
-                                <input ng-model="blade.currentEntity.email" type="email" placeholder="{{ 'stores.blades.store-advanced.placeholders.store-email' | translate }}">
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label">{{ 'stores.blades.store-advanced.labels.store-admin-email' | translate }}</label>
-                            <div class="form-input">
-                                <input ng-model="blade.currentEntity.adminEmail" type="email" placeholder="{{ 'stores.blades.store-advanced.placeholders.store-admin-email' | translate }}">
-                            </div>
-                        </div>
-                    </div>
+              </div>
+              <div class="form-group">
+                <label class="form-label">{{ 'stores.blades.store-advanced.labels.store-admin-email-name' | translate }}</label>
+                <div class="form-input">
+                  <input ng-model="blade.currentEntity.adminEmailName" ng-pattern="/^(?!.*[*|\x22:<>[\]{}`%';@&$])/" ng-maxlength="256" placeholder="{{ 'stores.blades.store-advanced.placeholders.store-admin-email-name' | translate }}">
                 </div>
-		<fieldset>
-            </form>
-        </div>
+              </div>
+            </div>
+            <div class="column">
+              <div class="form-group">
+                <label class="form-label">{{ 'stores.blades.store-advanced.labels.store-email' | translate }}</label>
+                <div class="form-input">
+                  <input ng-model="blade.currentEntity.email" type="email" ng-maxlength="128" placeholder="{{ 'stores.blades.store-advanced.placeholders.store-email' | translate }}">
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="form-label">{{ 'stores.blades.store-advanced.labels.store-admin-email' | translate }}</label>
+                <div class="form-input">
+                  <input ng-model="blade.currentEntity.adminEmail" type="email" ng-maxlength="128" placeholder="{{ 'stores.blades.store-advanced.placeholders.store-admin-email' | translate }}">
+                </div>
+              </div>
+            </div>
+          </div>
+        </fieldset>
+      </form>
     </div>
+  </div>
 </div>

--- a/src/VirtoCommerce.StoreModule.Web/package-lock.json
+++ b/src/VirtoCommerce.StoreModule.Web/package-lock.json
@@ -531,10 +531,11 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",


### PR DESCRIPTION
## Description
fix: Added max length client-side validation for email input fields.
fix: Updated `cross-spawn` package in `package-lock.json` from version `7.0.3` to `7.0.6`, including an updated `integrity` hash and an added `license` field specifying the MIT license.


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-2113
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Store_3.811.0-pr-143-e701.zip