### PR TITLE
VCST-3138: Use ObjectType as priority when selecting the SEO info

### DIFF
--- a/src/VirtoCommerce.StoreModule.Core/Extensions/SeoExtensions.cs
+++ b/src/VirtoCommerce.StoreModule.Core/Extensions/SeoExtensions.cs
@@ -35,8 +35,7 @@ public static class SeoExtensions
 
     // unknown object types should have the lowest priority
     // so, the array should be reversed to have the lowest priority at the end
-    // todo: should be moved to settings and has reverse order
-    private static readonly string[] PrioritiesSettings =
+    private static readonly string[] OrderedObjectTypes =
     [
         "CatalogProduct",
         "Category",
@@ -44,6 +43,14 @@ public static class SeoExtensions
         "Pages",
         "ContentFile"
     ];
+
+    private static bool SeoCanBeFound(SeoInfo seoInfo, string storeId, string storeDefaultLanguage, string language, string slug, string permalink)
+    {
+        // some conditions should be checked before calculating the score 
+        return (seoInfo.StoreId.IsNullOrEmpty() || seoInfo.StoreId == storeId) &&
+               (seoInfo.SemanticUrl.EqualsWithoutSlash(permalink) || seoInfo.SemanticUrl.EqualsWithoutSlash(slug)) &&
+               (seoInfo.LanguageCode.IsNullOrEmpty() || seoInfo.LanguageCode.EqualsIgnoreCase(language) || seoInfo.LanguageCode.EqualsIgnoreCase(storeDefaultLanguage));
+    }
 
     /// <summary>
     /// Returns SEO record with the highest score
@@ -56,14 +63,12 @@ public static class SeoExtensions
             return null;
         }
 
-        var priorities = PrioritiesSettings; // .Reverse().ToArray();
-
         return seoInfos
             ?.Where(x => SeoCanBeFound(x, storeId, storeDefaultLanguage, language, slug, permalink))
             .Select(seoInfo => new
             {
                 SeoRecord = seoInfo,
-                ObjectTypePriority = Array.IndexOf(priorities, seoInfo.ObjectType),
+                ObjectTypePriority = Array.IndexOf(OrderedObjectTypes, seoInfo.ObjectType),
                 Score = seoInfo.CalculateScore(storeId, storeDefaultLanguage, language, slug, permalink),
             })
             .Where(x => x.Score > 0)
@@ -99,14 +104,6 @@ public static class SeoExtensions
         // it transforms into binary: 1101001b = 105d
 
         return score;
-    }
-
-    private static bool SeoCanBeFound(SeoInfo seoInfo, string storeId, string storeDefaultLanguage, string language, string slug, string permalink)
-    {
-        // some conditions should be checked before calculating the score 
-        return (seoInfo.StoreId.IsNullOrEmpty() || seoInfo.StoreId == storeId)
-                && (seoInfo.SemanticUrl.EqualsWithoutSlash(permalink) || seoInfo.SemanticUrl.EqualsWithoutSlash(slug))
-                && (seoInfo.LanguageCode.IsNullOrEmpty() || seoInfo.LanguageCode.EqualsIgnoreCase(language) || seoInfo.LanguageCode.EqualsIgnoreCase(storeDefaultLanguage));
     }
 
     private static bool EqualsWithoutSlash(this string a, string b)

--- a/src/VirtoCommerce.StoreModule.Core/Extensions/SeoExtensions.cs
+++ b/src/VirtoCommerce.StoreModule.Core/Extensions/SeoExtensions.cs
@@ -77,7 +77,7 @@ public static class SeoExtensions
 
         // the order of this array is important
         // the first element has the highest priority
-        // so, we need to reverse it before calculating the score
+        // the array is reversed below using the .Reverse() method to prioritize elements correctly
         var score = new[]
             {
                 seoInfo.IsActive,

--- a/src/VirtoCommerce.StoreModule.Core/Extensions/SeoExtensions.cs
+++ b/src/VirtoCommerce.StoreModule.Core/Extensions/SeoExtensions.cs
@@ -35,7 +35,7 @@ public static class SeoExtensions
 
     // unknown object types should have the lowest priority
     // so, the array should be reversed to have the lowest priority at the end
-    private static readonly string[] OrderedObjectTypes =
+    private static readonly string[] _orderedObjectTypes =
     [
         "CatalogProduct",
         "Category",
@@ -43,14 +43,6 @@ public static class SeoExtensions
         "Pages",
         "ContentFile"
     ];
-
-    private static bool SeoCanBeFound(SeoInfo seoInfo, string storeId, string storeDefaultLanguage, string language, string slug, string permalink)
-    {
-        // some conditions should be checked before calculating the score 
-        return (seoInfo.StoreId.IsNullOrEmpty() || seoInfo.StoreId == storeId) &&
-               (seoInfo.SemanticUrl.EqualsWithoutSlash(permalink) || seoInfo.SemanticUrl.EqualsWithoutSlash(slug)) &&
-               (seoInfo.LanguageCode.IsNullOrEmpty() || seoInfo.LanguageCode.EqualsIgnoreCase(language) || seoInfo.LanguageCode.EqualsIgnoreCase(storeDefaultLanguage));
-    }
 
     /// <summary>
     /// Returns SEO record with the highest score
@@ -68,7 +60,7 @@ public static class SeoExtensions
             .Select(seoInfo => new
             {
                 SeoRecord = seoInfo,
-                ObjectTypePriority = Array.IndexOf(OrderedObjectTypes, seoInfo.ObjectType),
+                ObjectTypePriority = Array.IndexOf(_orderedObjectTypes, seoInfo.ObjectType),
                 Score = seoInfo.CalculateScore(storeId, storeDefaultLanguage, language, slug, permalink),
             })
             .Where(x => x.Score > 0)
@@ -76,6 +68,14 @@ public static class SeoExtensions
             .ThenByDescending(x => x.ObjectTypePriority)
             .Select(x => x.SeoRecord)
             .FirstOrDefault();
+    }
+
+    private static bool SeoCanBeFound(SeoInfo seoInfo, string storeId, string storeDefaultLanguage, string language, string slug, string permalink)
+    {
+        // some conditions should be checked before calculating the score 
+        return (seoInfo.StoreId.IsNullOrEmpty() || seoInfo.StoreId == storeId) &&
+               (seoInfo.SemanticUrl.EqualsWithoutSlash(permalink) || seoInfo.SemanticUrl.EqualsWithoutSlash(slug)) &&
+               (seoInfo.LanguageCode.IsNullOrEmpty() || seoInfo.LanguageCode.EqualsIgnoreCase(language) || seoInfo.LanguageCode.EqualsIgnoreCase(storeDefaultLanguage));
     }
 
     private static int CalculateScore(this SeoInfo seoInfo, string storeId, string storeDefaultLanguage, string language, string slug, string permalink)

--- a/src/VirtoCommerce.StoreModule.Core/Extensions/SeoExtensions.cs
+++ b/src/VirtoCommerce.StoreModule.Core/Extensions/SeoExtensions.cs
@@ -44,7 +44,7 @@ public static class SeoExtensions
             return null;
         }
 
-        // todo: should me moved to settings
+        // todo: should be moved to settings
         var prioritiesSettings = new[] { "ContentFile", "Pages", "Catalog", "Category", "CatalogProduct" };
 
         // unknown object types should have the lowest priority

--- a/src/VirtoCommerce.StoreModule.Core/Extensions/SeoExtensions.cs
+++ b/src/VirtoCommerce.StoreModule.Core/Extensions/SeoExtensions.cs
@@ -51,26 +51,30 @@ public static class SeoExtensions
         // so, the array should be reversed to have the lowest priority at the end
         var priorities = prioritiesSettings.Reverse().ToArray();
 
-        var scores = seoInfos
+        return seoInfos
             ?.Select(seoInfo => new
             {
                 SeoRecord = seoInfo,
                 ObjectTypePriority = Array.IndexOf(priorities, seoInfo.ObjectType),
                 Score = seoInfo.CalculateScore(storeId, storeDefaultLanguage, language, slug, permalink),
-            }).ToList();
-
-        var result = scores?
+            })
+            .Where(x => x.Score > 0)
             .OrderByDescending(x => x.Score)
             .ThenByDescending(x => x.ObjectTypePriority)
             .Select(x => x.SeoRecord)
             .FirstOrDefault();
-
-        return result;
     }
-
 
     private static int CalculateScore(this SeoInfo seoInfo, string storeId, string storeDefaultLanguage, string language, string slug, string permalink)
     {
+        // some conditions should be checked before calculating the score 
+        if ((!seoInfo.StoreId.IsNullOrEmpty() && seoInfo.StoreId != storeId)
+            || (!seoInfo.SemanticUrl.EqualsWithoutSlash(permalink) && !seoInfo.SemanticUrl.EqualsWithoutSlash(slug))
+            || (!seoInfo.LanguageCode.IsNullOrEmpty() && !seoInfo.LanguageCode.EqualsIgnoreCase(language) && !seoInfo.LanguageCode.EqualsIgnoreCase(storeDefaultLanguage)))
+        {
+            return 0;
+        }
+
         // the order of this array is important
         // the first element has the highest priority
         // so, we need to reverse it before calculating the score

--- a/tests/VirtoCommerce.StoreModule.Tests/SeoExtensionsTests.cs
+++ b/tests/VirtoCommerce.StoreModule.Tests/SeoExtensionsTests.cs
@@ -105,11 +105,166 @@ namespace VirtoCommerce.StoreModule.Tests
             };
 
             // Act
-            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "de-DE", slug: "product1");
+            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "en-US", slug: "product1");
 
             // Assert
             Assert.NotNull(result);
             Assert.Equal("Pages", result.ObjectType);
+        }
+
+        [Fact]
+        public void GetBestMatchingSeoInfo_NonEqualPermalink_ReturnsNull()
+        {
+            // Arrange
+            var store = new Store { Id = "Store1", DefaultLanguage = "en-US", };
+
+            var seoInfos = new List<SeoInfo>
+            {
+                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Category"},
+                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Pages"},
+            };
+
+            // Act
+            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "en-US", permalink: "product2");
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetBestMatchingSeoInfo_NonEqualSlug_ReturnsNull()
+        {
+            // Arrange
+            var store = new Store { Id = "Store1", DefaultLanguage = "en-US", };
+
+            var seoInfos = new List<SeoInfo>
+            {
+                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Category"},
+                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Pages"},
+            };
+
+            // Act
+            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "en-US", slug: "product2");
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetBestMatchingSeoInfo_NonEqualStore_ReturnsNull()
+        {
+            // Arrange
+            var store = new Store { Id = "Store2", DefaultLanguage = "en-US", };
+
+            var seoInfos = new List<SeoInfo>
+            {
+                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Category"},
+                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Pages"},
+            };
+
+            // Act
+            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "en-US", slug: "product1");
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetBestMatchingSeoInfo_NonEqualLanguage_ReturnsNull()
+        {
+            // Arrange
+            var store = new Store { Id = "Store1", DefaultLanguage = "en-US", };
+
+            var seoInfos = new List<SeoInfo>
+            {
+                new() { StoreId = "Store1", LanguageCode = "de-DE", SemanticUrl = "product1", ObjectType = "Category"},
+                new() { StoreId = "Store1", LanguageCode = "de-DE", SemanticUrl = "product1", ObjectType = "Pages"},
+            };
+
+            // Act
+            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "en-US", slug: "product1");
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetBestMatchingSeoInfo_WithEmptyStore_ReturnsValue()
+        {
+            // Arrange
+            var store = new Store { Id = "Store2", DefaultLanguage = "en-US", };
+
+            var seoInfos = new List<SeoInfo>
+            {
+                new() { StoreId = null, LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Category"},
+                new() { StoreId = null, LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Pages"},
+            };
+
+            // Act
+            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "en-US", slug: "product1");
+
+            // Assert
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void GetBestMatchingSeoInfo_WithCorrectParameters_ReturnsActive()
+        {
+            // Arrange
+            var store = new Store { Id = "Store2", DefaultLanguage = "en-US", };
+
+            var seoInfos = new List<SeoInfo>
+            {
+                new() { StoreId = null, LanguageCode = "en-US", SemanticUrl = "product1", IsActive = false },
+                new() { StoreId = null, LanguageCode = "en-US", SemanticUrl = "product1"},
+            };
+
+            // Act
+            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "en-US", slug: "product1");
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.True(result.IsActive);
+        }
+
+        [Fact]
+        public void GetBestMatchingSeoInfo_WithInactiveAndUrl_ReturnsInactive()
+        {
+            // Arrange
+            var store = new Store { Id = "Store2", DefaultLanguage = "en-US", };
+
+            var seoInfos = new List<SeoInfo>
+            {
+                new() { StoreId = null, LanguageCode = "en-US", SemanticUrl = "product2", IsActive = false },
+                new() { StoreId = null, LanguageCode = "en-US", SemanticUrl = "product1"},
+            };
+
+            // Act
+            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "en-US", slug: "product2");
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.False(result.IsActive);
+        }
+
+        [Fact]
+        public void GetBestMatchingSeoInfo_SemanticUrl_IsHigherStore()
+        {
+            // Arrange
+            var store = new Store { Id = "Store2", DefaultLanguage = "en-US", };
+
+            var seoInfos = new List<SeoInfo>
+            {
+                new() { StoreId = "Store2", LanguageCode = "en-US", SemanticUrl = "category/product2"},
+                new() { StoreId = null, LanguageCode = "en-US", SemanticUrl = "category/product2"},
+            };
+
+            // Act
+            var result = seoInfos.GetBestMatchingSeoInfo(store, language: null, permalink: "category/product2", slug: "product2");
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Store2", result.StoreId);
         }
     }
 }

--- a/tests/VirtoCommerce.StoreModule.Tests/SeoExtensionsTests.cs
+++ b/tests/VirtoCommerce.StoreModule.Tests/SeoExtensionsTests.cs
@@ -105,7 +105,7 @@ namespace VirtoCommerce.StoreModule.Tests
             };
 
             // Act
-            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "en-US", slug: "product1");
+            var result = seoInfos.GetBestMatchingSeoInfo(store.Id, store.DefaultLanguage, language: "en-US", slug: "product1");
 
             // Assert
             Assert.NotNull(result);

--- a/tests/VirtoCommerce.StoreModule.Tests/SeoExtensionsTests.cs
+++ b/tests/VirtoCommerce.StoreModule.Tests/SeoExtensionsTests.cs
@@ -123,12 +123,12 @@ namespace VirtoCommerce.StoreModule.Tests
 
             var seoInfos = new List<SeoInfo>
             {
-                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Category"},
-                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Pages"},
+                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "page1", ObjectType = "Category"},
+                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "page1", ObjectType = "Pages"},
             };
 
             // Act
-            var result = seoInfos.GetBestMatchingSeoInfo(store.Id, store.DefaultLanguage, language: "en-US", slug: "product1");
+            var result = seoInfos.GetBestMatchingSeoInfo(store.Id, store.DefaultLanguage, language: "en-US", slug: "page1");
 
             // Assert
             Assert.NotNull(result);
@@ -143,12 +143,12 @@ namespace VirtoCommerce.StoreModule.Tests
 
             var seoInfos = new List<SeoInfo>
             {
-                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Category"},
-                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Pages"},
+                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "page1", ObjectType = "Category"},
+                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "page1", ObjectType = "Pages"},
             };
 
             // Act
-            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "en-US", permalink: "product2");
+            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "en-US", permalink: "page2");
 
             // Assert
             Assert.Null(result);
@@ -162,12 +162,12 @@ namespace VirtoCommerce.StoreModule.Tests
 
             var seoInfos = new List<SeoInfo>
             {
-                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Category"},
-                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Pages"},
+                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "page1", ObjectType = "Category"},
+                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "page1", ObjectType = "Pages"},
             };
 
             // Act
-            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "en-US", slug: "product2");
+            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "en-US", slug: "page2");
 
             // Assert
             Assert.Null(result);
@@ -181,12 +181,12 @@ namespace VirtoCommerce.StoreModule.Tests
 
             var seoInfos = new List<SeoInfo>
             {
-                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Category"},
-                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Pages"},
+                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "page1", ObjectType = "Category"},
+                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "page1", ObjectType = "Pages"},
             };
 
             // Act
-            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "en-US", slug: "product1");
+            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "en-US", slug: "page1");
 
             // Assert
             Assert.Null(result);
@@ -200,12 +200,12 @@ namespace VirtoCommerce.StoreModule.Tests
 
             var seoInfos = new List<SeoInfo>
             {
-                new() { StoreId = "Store1", LanguageCode = "de-DE", SemanticUrl = "product1", ObjectType = "Category"},
-                new() { StoreId = "Store1", LanguageCode = "de-DE", SemanticUrl = "product1", ObjectType = "Pages"},
+                new() { StoreId = "Store1", LanguageCode = "de-DE", SemanticUrl = "page1", ObjectType = "Category"},
+                new() { StoreId = "Store1", LanguageCode = "de-DE", SemanticUrl = "page1", ObjectType = "Pages"},
             };
 
             // Act
-            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "en-US", slug: "product1");
+            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "en-US", slug: "page1");
 
             // Assert
             Assert.Null(result);
@@ -219,12 +219,12 @@ namespace VirtoCommerce.StoreModule.Tests
 
             var seoInfos = new List<SeoInfo>
             {
-                new() { StoreId = null, LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Category"},
-                new() { StoreId = null, LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Pages"},
+                new() { StoreId = null, LanguageCode = "en-US", SemanticUrl = "page1", ObjectType = "Category"},
+                new() { StoreId = null, LanguageCode = "en-US", SemanticUrl = "page1", ObjectType = "Pages"},
             };
 
             // Act
-            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "en-US", slug: "product1");
+            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "en-US", slug: "page1");
 
             // Assert
             Assert.NotNull(result);

--- a/tests/VirtoCommerce.StoreModule.Tests/SeoExtensionsTests.cs
+++ b/tests/VirtoCommerce.StoreModule.Tests/SeoExtensionsTests.cs
@@ -91,5 +91,25 @@ namespace VirtoCommerce.StoreModule.Tests
             Assert.NotNull(result);
             Assert.Null(result.LanguageCode);
         }
+
+        [Fact]
+        public void GetBestMatchingSeoInfo_WithObjectType_ReturnsSeoInfoWithHighPriority()
+        {
+            // Arrange
+            var store = new Store { Id = "Store1", DefaultLanguage = "en-US", };
+
+            var seoInfos = new List<SeoInfo>
+            {
+                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Category"},
+                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "product1", ObjectType = "Pages"},
+            };
+
+            // Act
+            var result = seoInfos.GetBestMatchingSeoInfo(store, language: "de-DE", slug: "product1");
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Pages", result.ObjectType);
+        }
     }
 }

--- a/tests/VirtoCommerce.StoreModule.Tests/SeoExtensionsTests.cs
+++ b/tests/VirtoCommerce.StoreModule.Tests/SeoExtensionsTests.cs
@@ -28,6 +28,29 @@ namespace VirtoCommerce.StoreModule.Tests
         }
 
         [Fact]
+        public void GetBestMatchingSeoInfo_WithNullLanguage_ReturnsPage()
+        {
+            var store = new Store { Id = "Store1", DefaultLanguage = "en-US", };
+            // Arrange
+            var seoInfos = new List<SeoInfo>
+            {
+                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "product1" },
+                new() { StoreId = "Store1", LanguageCode = "en-US", SemanticUrl = "product2" },
+                new() { StoreId = "Store2", LanguageCode = "en-US", SemanticUrl = "product1" },
+                new() { StoreId = "Store2", LanguageCode = "en-US", SemanticUrl = "product2" },
+            };
+
+            // Act
+            var result = seoInfos.GetBestMatchingSeoInfo(store, language: null, slug: "product1");
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Store1", result.StoreId);
+            Assert.Equal("en-US", result.LanguageCode);
+            Assert.Equal("product1", result.SemanticUrl);
+        }
+
+        [Fact]
         public void GetBestMatchingSeoInfo_WithValidParameters_ReturnsSeoInfo()
         {
             // Arrange


### PR DESCRIPTION
## Description

* Add priority of object types with score calculating to select more suitable seo info
* Add tests

## References
### QA-test:
### Jira-link:






https://virtocommerce.atlassian.net/browse/VCST-3138
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Store_3.814.0-pr-149-31b9.zip