### PR TITLE
VCST-3622: Update translations for linked-stores and notifications

### DIFF
--- a/src/VirtoCommerce.StoreModule.Web/Localizations/de.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/de.VirtoCommerce.Store.json
@@ -62,7 +62,7 @@
           "additional-languages": "Zusätzliche Sprachen",
           "default-currency": "Standardwährung",
           "additional-currencies": "Zusätzliche Währungen",
-          "linked-stores": "Verknüpfte Shops (Kunden können ihre Anmeldeinformationen verwenden, um auf diese Shops zuzugreifen)"
+          "linked-stores": "Verknüpfte Shops (Kunden dieser Shops können ihre Zugangsdaten zur Anmeldung verwenden)"
         },
         "placeholders": {
           "code": "Code angeben",

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/en.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/en.VirtoCommerce.Store.json
@@ -62,7 +62,7 @@
           "additional-languages": "Additional languages",
           "default-currency": "Default currency",
           "additional-currencies": "Additional currencies",
-          "linked-stores": "Linked stores (customers can use their credentials to access these stores)"
+          "linked-stores": "Linked stores (customers from these stores can use their credentials to sign in)"
         },
         "placeholders": {
           "code": "Provide code",

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/es.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/es.VirtoCommerce.Store.json
@@ -62,7 +62,7 @@
           "additional-languages": "Idiomas adicionales",
           "default-currency": "Moneda predeterminada",
           "additional-currencies": "Monedas adicionales",
-          "linked-stores": "Tiendas vinculadas (los clientes pueden usar sus credenciales para acceder a estas tiendas)"
+          "linked-stores": "Tiendas vinculadas (los clientes de estas tiendas pueden usar sus credenciales para iniciar sesión)"
         },
         "placeholders": {
           "code": "Proporcionar código",

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/fr.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/fr.VirtoCommerce.Store.json
@@ -62,7 +62,7 @@
           "additional-languages": "Langues supplémentaires",
           "default-currency": "Devise par défaut",
           "additional-currencies": "Devises supplémentaires",
-          "linked-stores": "Magasins liés (les clients peuvent utiliser leurs identifiants pour accéder à ces magasins)"
+          "linked-stores": "Boutiques liées (les clients de ces boutiques peuvent utiliser leurs identifiants pour se connecter)"
         },
         "placeholders": {
           "code": "Fournir un code",

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/it.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/it.VirtoCommerce.Store.json
@@ -62,7 +62,7 @@
           "additional-languages": "Lingue aggiuntive",
           "default-currency": "Valuta predefinita",
           "additional-currencies": "Valute aggiuntive",
-          "linked-stores": "Negozi collegati (i clienti possono utilizzare le proprie credenziali per accedere a questi negozi)"
+          "linked-stores": "Negozi collegati (i clienti di questi negozi possono utilizzare le proprie credenziali per accedere)"
         },
         "placeholders": {
           "code": "Fornire codice",

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/ja.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/ja.VirtoCommerce.Store.json
@@ -62,7 +62,7 @@
           "additional-languages": "追加の言語",
           "default-currency": "デフォルトの通貨",
           "additional-currencies": "追加の通貨",
-          "linked-stores": "リンクされたストア（顧客はこれらのストアにアクセスするために自分の資格情報を使用できます）"
+          "linked-stores": "連携ストア（これらのストアの顧客は自分の認証情報でサインインできます）"
         },
         "placeholders": {
           "code": "コードを提供",

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/pl.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/pl.VirtoCommerce.Store.json
@@ -62,7 +62,7 @@
           "additional-languages": "Dodatkowe języki",
           "default-currency": "Waluta domyślna",
           "additional-currencies": "Dodatkowe waluty",
-          "linked-stores": "Połączone sklepy (klienci mogą używać swoich danych logowania, aby uzyskać dostęp do tych sklepów)"
+          "linked-stores": "Powiązane sklepy (klienci tych sklepów mogą używać swoich danych logowania do zalogowania się)"
         },
         "placeholders": {
           "code": "Podaj kod",

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/pt.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/pt.VirtoCommerce.Store.json
@@ -62,7 +62,7 @@
           "additional-languages": "Idiomas adicionais",
           "default-currency": "Moeda padrão",
           "additional-currencies": "Moedas adicionais",
-          "linked-stores": "Lojas vinculadas (os clientes podem usar suas credenciais para acessar essas lojas)"
+          "linked-stores": "Lojas vinculadas (clientes dessas lojas podem usar suas credenciais para fazer login)"
         },
         "placeholders": {
           "code": "Fornecer código",


### PR DESCRIPTION
## Description
fix: Clarified linked stores translations across multiple languages to indicate that customers can sign in to the current store using their credentials from linked stores.

## References
### QA-test:
### Jira-link:
### Artifact URL:
