### PR TITLE
VCST-4516: Update SEO widget reference to use Seo module instead of Core

### DIFF
--- a/src/VirtoCommerce.StoreModule.Core/VirtoCommerce.StoreModule.Core.csproj
+++ b/src/VirtoCommerce.StoreModule.Core/VirtoCommerce.StoreModule.Core.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1003.0-alpha.1690-vcst-4516" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016.0" />
     <PackageReference Include="VirtoCommerce.Seo.Core" Version="3.1002.0-alpha.74-vcst-4516" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.StoreModule.Core/VirtoCommerce.StoreModule.Core.csproj
+++ b/src/VirtoCommerce.StoreModule.Core/VirtoCommerce.StoreModule.Core.csproj
@@ -9,9 +9,9 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1003.0-alpha.1690-vcst-4516" />
+    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1003.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016.0" />
-    <PackageReference Include="VirtoCommerce.Seo.Core" Version="3.1002.0-alpha.74-vcst-4516" />
+    <PackageReference Include="VirtoCommerce.Seo.Core" Version="3.1002.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.StoreModule.Core/VirtoCommerce.StoreModule.Core.csproj
+++ b/src/VirtoCommerce.StoreModule.Core/VirtoCommerce.StoreModule.Core.csproj
@@ -9,9 +9,9 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1003.0-alpha.1690-vcst-4516" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1013.0" />
-    <PackageReference Include="VirtoCommerce.Seo.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Seo.Core" Version="3.1002.0-alpha.74-vcst-4516" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.StoreModule.Data.MySql/VirtoCommerce.StoreModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.StoreModule.Data.MySql/VirtoCommerce.StoreModule.Data.MySql.csproj
@@ -6,11 +6,11 @@
     <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.StoreModule.Data\VirtoCommerce.StoreModule.Data.csproj" />

--- a/src/VirtoCommerce.StoreModule.Data.PostgreSql/VirtoCommerce.StoreModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.StoreModule.Data.PostgreSql/VirtoCommerce.StoreModule.Data.PostgreSql.csproj
@@ -6,11 +6,11 @@
     <noWarn>NU1903</noWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.StoreModule.Data\VirtoCommerce.StoreModule.Data.csproj" />

--- a/src/VirtoCommerce.StoreModule.Data.SqlServer/VirtoCommerce.StoreModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.StoreModule.Data.SqlServer/VirtoCommerce.StoreModule.Data.SqlServer.csproj
@@ -5,11 +5,11 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.StoreModule.Data\VirtoCommerce.StoreModule.Data.csproj" />

--- a/src/VirtoCommerce.StoreModule.Data/VirtoCommerce.StoreModule.Data.csproj
+++ b/src/VirtoCommerce.StoreModule.Data/VirtoCommerce.StoreModule.Data.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="VirtoCommerce.CoreModule.Data" Version="3.1003.0-alpha.1690-vcst-4516" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1013.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.StoreModule.Core\VirtoCommerce.StoreModule.Core.csproj" />

--- a/src/VirtoCommerce.StoreModule.Data/VirtoCommerce.StoreModule.Data.csproj
+++ b/src/VirtoCommerce.StoreModule.Data/VirtoCommerce.StoreModule.Data.csproj
@@ -8,7 +8,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.CoreModule.Data" Version="3.1003.0-alpha.1690-vcst-4516" />
+    <PackageReference Include="VirtoCommerce.CoreModule.Data" Version="3.1003.0" />
     <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1016.0" />
     <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1016.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.StoreModule.Data/VirtoCommerce.StoreModule.Data.csproj
+++ b/src/VirtoCommerce.StoreModule.Data/VirtoCommerce.StoreModule.Data.csproj
@@ -8,7 +8,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.CoreModule.Data" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.CoreModule.Data" Version="3.1003.0-alpha.1690-vcst-4516" />
     <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1013.0" />
     <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1013.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.StoreModule.Web/Scripts/store.js
+++ b/src/VirtoCommerce.StoreModule.Web/Scripts/store.js
@@ -58,12 +58,13 @@ angular.module(moduleName, [
                     template: 'Modules/$(VirtoCommerce.Store)/Scripts/widgets/assetsWidget.tpl.html'
                 }, 'storeDetail');
                 widgetService.registerWidget({
-                    controller: 'virtoCommerce.coreModule.seo.seoWidgetController',
-                    template: 'Modules/$(VirtoCommerce.Core)/Scripts/SEO/widgets/seoWidget.tpl.html',
+                    controller: 'virtoCommerce.seo.seoWidgetController',
+                    template: 'Modules/$(VirtoCommerce.Seo)/Scripts/widgets/seo-widget.html',
                     objectType: 'Store',
                     getFixedStoreId: function (blade) { return blade.currentEntity.id; },
                     getDefaultContainerId: function (blade) { return blade.currentEntity.id; },
-                    getLanguages: function (blade) { return blade.currentEntity.languages; }
+                    getLanguages: function (blade) { return blade.currentEntity.languages; },
+                    getStoreDataSource: function (blade) { return function () { return [blade.currentEntity]; }; },
                 }, 'storeDetail');
                 widgetService.registerWidget({
                     controller: 'virtoCommerce.storeModule.storeAdvancedWidgetController',

--- a/src/VirtoCommerce.StoreModule.Web/module.manifest
+++ b/src/VirtoCommerce.StoreModule.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1002.0</version>
   <version-tag />
 
-  <platformVersion>3.1013.0</platformVersion>
+  <platformVersion>3.1016.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Core" version="3.1003.0-alpha.1690-vcst-4516" />
     <dependency id="VirtoCommerce.Notifications" version="3.1000.0" />

--- a/src/VirtoCommerce.StoreModule.Web/module.manifest
+++ b/src/VirtoCommerce.StoreModule.Web/module.manifest
@@ -6,9 +6,9 @@
 
   <platformVersion>3.1013.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Core" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Core" version="3.1003.0-alpha.1690-vcst-4516" />
     <dependency id="VirtoCommerce.Notifications" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Seo" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Seo" version="3.1002.0-alpha.74-vcst-4516" />
   </dependencies>
 
   <title>Store</title>

--- a/src/VirtoCommerce.StoreModule.Web/module.manifest
+++ b/src/VirtoCommerce.StoreModule.Web/module.manifest
@@ -6,9 +6,9 @@
 
   <platformVersion>3.1016.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Core" version="3.1003.0-alpha.1690-vcst-4516" />
+    <dependency id="VirtoCommerce.Core" version="3.1003.0" />
     <dependency id="VirtoCommerce.Notifications" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Seo" version="3.1002.0-alpha.74-vcst-4516" />
+    <dependency id="VirtoCommerce.Seo" version="3.1002.0" />
   </dependencies>
 
   <title>Store</title>


### PR DESCRIPTION
## Description

- Updated SEO widget registration for Store to use new controller and template from VirtoCommerce.Seo module
- Replaced `getStores` with `getStoreDataSource` callback for consistency with other modules

### Changes

**store.js**:
- Controller: `virtoCommerce.coreModule.seo.seoWidgetController` → `virtoCommerce.seo.seoWidgetController`
- Template: `Modules/$(VirtoCommerce.Core)/Scripts/SEO/widgets/seoWidget.tpl.html` → `Modules/$(VirtoCommerce.Seo)/Scripts/widgets/seo-widget.html`
- `getStores` → `getStoreDataSource` (store selector is hidden via `fixedStoreId`, but callback provided for consistency)

### Related

Companion PRs: vc-module-seo, vc-module-core, vc-module-catalog, vc-module-customer, vc-module-catalog-publishing, vc-docs

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4516
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Store_3.1002.0-pr-167-a667.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to dependency version bumps (Platform/Core/Seo and EF design packages) and a UI integration change that could break the Store SEO widget if module assets/controller names don’t match deployed versions.
> 
> **Overview**
> Updates the Store module’s SEO widget registration to use the new `VirtoCommerce.Seo` controller/template and adds a `getStoreDataSource` callback for the widget.
> 
> Bumps Store module dependencies and manifest requirements to newer `VirtoCommerce.Platform`/`VirtoCommerce.Core`/`VirtoCommerce.Seo` versions, and updates `Microsoft.EntityFrameworkCore.Design` in the database provider projects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a66793b44091b903b14bf21ceab1bd78f94158d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->