### PR TITLE
VCST-5089: Configure per-store Asset Public URL for XAPI asset links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The Store module provides multi-store management capabilities for the Virto Comm
 ## Key Features
 
 * **Multi-store management** — Create, update, delete, and search stores with configurable properties including name, URL, catalog, time zone, country, and region.
+* **Per-store asset public URL** — Serve each store's asset (image) URLs from its own domain (e.g. a store-specific CDN) instead of the shared platform/CDN domain via the `Store.AssetPublicUrl` property and the `IStoreAssetPublicUrlResolver` service.
 * **Per-store currency and language support** — Configure multiple currencies and languages per store with a designated default for each.
 * **Fulfillment center assignment** — Assign primary and alternate fulfillment centers for orders and returns per store.
 * **Store authentication schemes** — Manage per-store authentication providers (password login, external SSO) with ordering and activation controls.
@@ -36,6 +37,29 @@ The Store module provides multi-store management capabilities for the Virto Comm
 | `Stores.EmailVerificationRequired` | Boolean | `false` | Requires email verification before users can access the store. |
 | `Stores.EnablePriceRoundingForTotalsCalculation` | Boolean | `true` | Enables price rounding when calculating order totals. |
 | `Stores.SeoLinksType` | ShortText | `Collapsed` | SEO URL format type. Allowed values: `None`, `Short`, `Collapsed`, `Long`. |
+
+### Store Asset Public URL
+
+Each store can define its own base URL for public asset (image) links via the **Store asset URL** field in the store details blade (the `Store.AssetPublicUrl` property, also exposed through the Experience API `store` query). When set, the `IStoreAssetPublicUrlResolver` service combines relative asset paths with this base URL and rebases absolute platform asset URLs onto it, preserving the path, query string (e.g. SAS tokens), and fragment. When the field is empty, asset URLs are returned unchanged (global CDN / platform default). Serving the assets from the custom domain (DNS/CDN routing) is handled at the infrastructure level.
+
+The rewrite of absolute URLs can be restricted to specific source hosts with the `VirtoCommerce:StoreAssets` configuration section in `appsettings.json`:
+
+```json
+{
+  "VirtoCommerce": {
+    "StoreAssets": {
+      "KnownAssetHosts": [
+        "cdn.example.com",
+        "https://mycompany.blob.core.windows.net"
+      ]
+    }
+  }
+}
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `VirtoCommerce:StoreAssets:KnownAssetHosts` | `[]` | Hosts (bare domains or full URLs) of platform/CDN asset URLs that are allowed to be replaced with the store's asset public URL. When empty, any absolute asset URL is rebased. When set, only URLs whose host is listed (compared case-insensitively) are rebased; URLs on other hosts are treated as external and returned as-is. |
 
 ### Permissions
 
@@ -82,6 +106,7 @@ The Store module provides multi-store management capabilities for the Virto Comm
 | `StoreService` | `IStoreService` | CRUD operations for stores, including settings deep-load/save, validation, deletion with change log, and resolving user-allowed store IDs. |
 | `StoreSearchService` | `IStoreSearchService` | Search stores by keyword, object IDs, store states, fulfillment center IDs, and domain. |
 | `StoreCurrencyResolver` | `IStoreCurrencyResolver` | Resolves a specific currency or all currencies for a store with culture-aware formatting and caching. |
+| `StoreAssetPublicUrlResolver` | `IStoreAssetPublicUrlResolver` | Resolves store-aware public asset (image) URLs: combines relative paths with, or rebases absolute URLs onto, the store's `AssetPublicUrl`, optionally restricted by `VirtoCommerce:StoreAssets:KnownAssetHosts`. |
 | `StoreNotificationSender` | `IStoreNotificationSender` | Generates email verification links and sends confirmation email notifications for store users. |
 | `StoreSeoResolver` | `ISeoResolver` | Resolves SEO information by slug/permalink for stores with caching. |
 | `StoreSeoBySlugResolver` | `ISeoBySlugResolver` | Legacy (obsolete) SEO resolution by slug for backward compatibility. |

--- a/src/VirtoCommerce.StoreModule.Core/Model/Store.cs
+++ b/src/VirtoCommerce.StoreModule.Core/Model/Store.cs
@@ -40,6 +40,11 @@ namespace VirtoCommerce.StoreModule.Core.Model
         /// </summary>
         public string SecureUrl { get; set; }
         /// <summary>
+        /// Base URL used to build public asset (image) URLs for this store in the Experience API responses.
+        /// Overrides the global Assets PublicUrl. When empty, the global/admin default is used.
+        /// </summary>
+        public string AssetPublicUrl { get; set; }
+        /// <summary>
         /// Primary store contact email can be used for store event notifications and for feed back
         /// </summary>
         public string Email { get; set; }

--- a/src/VirtoCommerce.StoreModule.Core/Services/IStoreAssetPublicUrlResolver.cs
+++ b/src/VirtoCommerce.StoreModule.Core/Services/IStoreAssetPublicUrlResolver.cs
@@ -1,0 +1,17 @@
+using VirtoCommerce.StoreModule.Core.Model;
+
+namespace VirtoCommerce.StoreModule.Core.Services;
+
+/// <summary>
+/// Resolves a store-aware public asset (image) URL.
+/// When the store defines <see cref="Store.AssetPublicUrl"/>, relative URLs are combined with it and
+/// absolute URLs are rebased onto it; otherwise the URL is returned unchanged.
+/// </summary>
+public interface IStoreAssetPublicUrlResolver
+{
+    /// <param name="store">Store whose <see cref="Store.AssetPublicUrl"/> defines the asset domain. Required.</param>
+    /// <param name="url">Absolute or relative asset URL as stored/indexed. Returned as-is when null/empty,
+    /// a data:/blob: URI, when the store has no <see cref="Store.AssetPublicUrl"/> configured, or when
+    /// <see cref="StoreAssetsOptions.KnownAssetHosts"/> is set and the URL host is not listed there.</param>
+    string GetAbsoluteUrl(Store store, string url);
+}

--- a/src/VirtoCommerce.StoreModule.Core/StoreAssetsOptions.cs
+++ b/src/VirtoCommerce.StoreModule.Core/StoreAssetsOptions.cs
@@ -1,0 +1,16 @@
+namespace VirtoCommerce.StoreModule.Core;
+
+/// <summary>
+/// Options for store-aware asset URL resolution. Bound from the "VirtoCommerce:StoreAssets" configuration section.
+/// </summary>
+public class StoreAssetsOptions
+{
+    public const string SectionName = "VirtoCommerce:StoreAssets";
+
+    /// <summary>
+    /// Hosts (domains) of platform/CDN asset URLs that are allowed to be replaced with the store's
+    /// AssetPublicUrl. When empty (default), any absolute asset URL is rebased. When set, only URLs
+    /// whose host is listed here are rebased; other hosts are treated as external and returned as-is.
+    /// </summary>
+    public string[] KnownAssetHosts { get; set; } = [];
+}

--- a/src/VirtoCommerce.StoreModule.Data.MySql/Migrations/20260714121723_AddStoreAssetPublicUrl.Designer.cs
+++ b/src/VirtoCommerce.StoreModule.Data.MySql/Migrations/20260714121723_AddStoreAssetPublicUrl.Designer.cs
@@ -2,78 +2,81 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VirtoCommerce.StoreModule.Data.Repositories;
 
 #nullable disable
 
-namespace VirtoCommerce.StoreModule.Data.PostgreSql.Migrations
+namespace VirtoCommerce.StoreModule.Data.MySql.Migrations
 {
     [DbContext(typeof(StoreDbContext))]
-    partial class StoreDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260714121723_AddStoreAssetPublicUrl")]
+    partial class AddStoreAssetPublicUrl
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "10.0.9")
-                .HasAnnotation("Relational:MaxIdentifierLength", 63);
+                .HasAnnotation("Relational:MaxIdentifierLength", 64);
 
-            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+            MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
 
             modelBuilder.Entity("VirtoCommerce.StoreModule.Data.Model.SeoInfoEntity", b =>
                 {
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("ImageAltDescription")
                         .HasMaxLength(255)
-                        .HasColumnType("character varying(255)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<bool>("IsActive")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Keyword")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("character varying(255)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("Language")
                         .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
+                        .HasColumnType("varchar(5)");
 
                     b.Property<string>("MetaDescription")
                         .HasMaxLength(1024)
-                        .HasColumnType("character varying(1024)");
+                        .HasColumnType("varchar(1024)");
 
                     b.Property<string>("MetaKeywords")
                         .HasMaxLength(255)
-                        .HasColumnType("character varying(255)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("StoreId")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("Title")
                         .HasMaxLength(255)
-                        .HasColumnType("character varying(255)");
+                        .HasColumnType("varchar(255)");
 
                     b.HasKey("Id");
 
@@ -87,37 +90,37 @@ namespace VirtoCommerce.StoreModule.Data.PostgreSql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<bool>("IsActive")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<int>("Position")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("StoreId")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.HasKey("Id");
 
@@ -133,16 +136,16 @@ namespace VirtoCommerce.StoreModule.Data.PostgreSql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("CurrencyCode")
                         .IsRequired()
                         .HasMaxLength(32)
-                        .HasColumnType("character varying(32)");
+                        .HasColumnType("varchar(32)");
 
                     b.Property<string>("StoreId")
                         .IsRequired()
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.HasKey("Id");
 
@@ -156,69 +159,69 @@ namespace VirtoCommerce.StoreModule.Data.PostgreSql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<bool?>("BooleanValue")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<DateTime?>("DateTimeValue")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<decimal?>("DecimalValue")
                         .HasColumnType("decimal(18,5)");
 
                     b.Property<string>("DictionaryItemId")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<int?>("IntegerValue")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("Locale")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<string>("LongTextValue")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("ObjectId")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("ObjectType")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("varchar(256)");
 
                     b.Property<string>("PropertyId")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("PropertyName")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("varchar(256)");
 
                     b.Property<string>("ShortTextValue")
                         .HasMaxLength(512)
-                        .HasColumnType("character varying(512)");
+                        .HasColumnType("varchar(512)");
 
                     b.Property<string>("ValueType")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.HasKey("Id");
 
@@ -235,104 +238,104 @@ namespace VirtoCommerce.StoreModule.Data.PostgreSql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("AdminEmail")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("AdminEmailName")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("varchar(256)");
 
                     b.Property<string>("AssetPublicUrl")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("varchar(256)");
 
                     b.Property<string>("Catalog")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("Country")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int>("CreditCardSavePolicy")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("DefaultCurrency")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<string>("DefaultLanguage")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("Description")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("varchar(256)");
 
                     b.Property<bool>("DisplayOutOfStock")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Email")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("EmailName")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("varchar(256)");
 
                     b.Property<string>("FulfillmentCenterId")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("Region")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("ReturnsFulfillmentCenterId")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("SecureUrl")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<int>("StoreState")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("TimeZone")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("Url")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("varchar(256)");
 
                     b.HasKey("Id");
 
@@ -346,26 +349,26 @@ namespace VirtoCommerce.StoreModule.Data.PostgreSql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("FulfillmentCenterId")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("StoreId")
                         .IsRequired()
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("Type")
                         .IsRequired()
                         .HasMaxLength(32)
-                        .HasColumnType("character varying(32)");
+                        .HasColumnType("varchar(32)");
 
                     b.HasKey("Id");
 
@@ -379,16 +382,16 @@ namespace VirtoCommerce.StoreModule.Data.PostgreSql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("LanguageCode")
                         .IsRequired()
                         .HasMaxLength(32)
-                        .HasColumnType("character varying(32)");
+                        .HasColumnType("varchar(32)");
 
                     b.Property<string>("StoreId")
                         .IsRequired()
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.HasKey("Id");
 
@@ -402,16 +405,16 @@ namespace VirtoCommerce.StoreModule.Data.PostgreSql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("GroupName")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("StoreId")
                         .IsRequired()
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.HasKey("Id");
 

--- a/src/VirtoCommerce.StoreModule.Data.MySql/Migrations/20260714121723_AddStoreAssetPublicUrl.cs
+++ b/src/VirtoCommerce.StoreModule.Data.MySql/Migrations/20260714121723_AddStoreAssetPublicUrl.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VirtoCommerce.StoreModule.Data.MySql.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStoreAssetPublicUrl : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AssetPublicUrl",
+                table: "Store",
+                type: "varchar(256)",
+                maxLength: 256,
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AssetPublicUrl",
+                table: "Store");
+        }
+    }
+}

--- a/src/VirtoCommerce.StoreModule.Data.MySql/Migrations/StoreDbContextModelSnapshot.cs
+++ b/src/VirtoCommerce.StoreModule.Data.MySql/Migrations/StoreDbContextModelSnapshot.cs
@@ -17,7 +17,7 @@ namespace VirtoCommerce.StoreModule.Data.MySql.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "8.0.11")
+                .HasAnnotation("ProductVersion", "10.0.9")
                 .HasAnnotation("Relational:MaxIdentifierLength", 64);
 
             MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
@@ -242,6 +242,10 @@ namespace VirtoCommerce.StoreModule.Data.MySql.Migrations
                         .HasColumnType("varchar(128)");
 
                     b.Property<string>("AdminEmailName")
+                        .HasMaxLength(256)
+                        .HasColumnType("varchar(256)");
+
+                    b.Property<string>("AssetPublicUrl")
                         .HasMaxLength(256)
                         .HasColumnType("varchar(256)");
 

--- a/src/VirtoCommerce.StoreModule.Data.MySql/Readme.md
+++ b/src/VirtoCommerce.StoreModule.Data.MySql/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.1
+dotnet tool install --global dotnet-ef --version 10.0.9
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.1
+dotnet tool update --global dotnet-ef --version 10.0.9
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.StoreModule.Data.MySql/VirtoCommerce.StoreModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.StoreModule.Data.MySql/VirtoCommerce.StoreModule.Data.MySql.csproj
@@ -6,7 +6,7 @@
     <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/VirtoCommerce.StoreModule.Data.PostgreSql/Migrations/20260714121715_AddStoreAssetPublicUrl.Designer.cs
+++ b/src/VirtoCommerce.StoreModule.Data.PostgreSql/Migrations/20260714121715_AddStoreAssetPublicUrl.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VirtoCommerce.StoreModule.Data.Repositories;
@@ -11,9 +12,11 @@ using VirtoCommerce.StoreModule.Data.Repositories;
 namespace VirtoCommerce.StoreModule.Data.PostgreSql.Migrations
 {
     [DbContext(typeof(StoreDbContext))]
-    partial class StoreDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260714121715_AddStoreAssetPublicUrl")]
+    partial class AddStoreAssetPublicUrl
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/VirtoCommerce.StoreModule.Data.PostgreSql/Migrations/20260714121715_AddStoreAssetPublicUrl.cs
+++ b/src/VirtoCommerce.StoreModule.Data.PostgreSql/Migrations/20260714121715_AddStoreAssetPublicUrl.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VirtoCommerce.StoreModule.Data.PostgreSql.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStoreAssetPublicUrl : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AssetPublicUrl",
+                table: "Store",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AssetPublicUrl",
+                table: "Store");
+        }
+    }
+}

--- a/src/VirtoCommerce.StoreModule.Data.PostgreSql/Readme.md
+++ b/src/VirtoCommerce.StoreModule.Data.PostgreSql/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.1
+dotnet tool install --global dotnet-ef --version 10.0.9
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.1
+dotnet tool update --global dotnet-ef --version 10.0.9
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.StoreModule.Data.PostgreSql/VirtoCommerce.StoreModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.StoreModule.Data.PostgreSql/VirtoCommerce.StoreModule.Data.PostgreSql.csproj
@@ -6,7 +6,7 @@
     <noWarn>NU1903</noWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/VirtoCommerce.StoreModule.Data.SqlServer/Migrations/20260714121708_AddStoreAssetPublicUrl.Designer.cs
+++ b/src/VirtoCommerce.StoreModule.Data.SqlServer/Migrations/20260714121708_AddStoreAssetPublicUrl.Designer.cs
@@ -2,78 +2,81 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VirtoCommerce.StoreModule.Data.Repositories;
 
 #nullable disable
 
-namespace VirtoCommerce.StoreModule.Data.PostgreSql.Migrations
+namespace VirtoCommerce.StoreModule.Data.SqlServer.Migrations
 {
     [DbContext(typeof(StoreDbContext))]
-    partial class StoreDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260714121708_AddStoreAssetPublicUrl")]
+    partial class AddStoreAssetPublicUrl
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "10.0.9")
-                .HasAnnotation("Relational:MaxIdentifierLength", 63);
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
-            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
             modelBuilder.Entity("VirtoCommerce.StoreModule.Data.Model.SeoInfoEntity", b =>
                 {
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("ImageAltDescription")
                         .HasMaxLength(255)
-                        .HasColumnType("character varying(255)");
+                        .HasColumnType("nvarchar(255)");
 
                     b.Property<bool>("IsActive")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Keyword")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("character varying(255)");
+                        .HasColumnType("nvarchar(255)");
 
                     b.Property<string>("Language")
                         .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
+                        .HasColumnType("nvarchar(5)");
 
                     b.Property<string>("MetaDescription")
                         .HasMaxLength(1024)
-                        .HasColumnType("character varying(1024)");
+                        .HasColumnType("nvarchar(1024)");
 
                     b.Property<string>("MetaKeywords")
                         .HasMaxLength(255)
-                        .HasColumnType("character varying(255)");
+                        .HasColumnType("nvarchar(255)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("StoreId")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Title")
                         .HasMaxLength(255)
-                        .HasColumnType("character varying(255)");
+                        .HasColumnType("nvarchar(255)");
 
                     b.HasKey("Id");
 
@@ -87,37 +90,37 @@ namespace VirtoCommerce.StoreModule.Data.PostgreSql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime2");
 
                     b.Property<bool>("IsActive")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<int>("Position")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("StoreId")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.HasKey("Id");
 
@@ -133,16 +136,16 @@ namespace VirtoCommerce.StoreModule.Data.PostgreSql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CurrencyCode")
                         .IsRequired()
                         .HasMaxLength(32)
-                        .HasColumnType("character varying(32)");
+                        .HasColumnType("nvarchar(32)");
 
                     b.Property<string>("StoreId")
                         .IsRequired()
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.HasKey("Id");
 
@@ -156,69 +159,69 @@ namespace VirtoCommerce.StoreModule.Data.PostgreSql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<bool?>("BooleanValue")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("DateTimeValue")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime2");
 
                     b.Property<decimal?>("DecimalValue")
                         .HasColumnType("decimal(18,5)");
 
                     b.Property<string>("DictionaryItemId")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<int?>("IntegerValue")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("Locale")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("LongTextValue")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("ObjectId")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ObjectType")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("PropertyId")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("PropertyName")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("ShortTextValue")
                         .HasMaxLength(512)
-                        .HasColumnType("character varying(512)");
+                        .HasColumnType("nvarchar(512)");
 
                     b.Property<string>("ValueType")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.HasKey("Id");
 
@@ -235,104 +238,104 @@ namespace VirtoCommerce.StoreModule.Data.PostgreSql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("AdminEmail")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("AdminEmailName")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("AssetPublicUrl")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("Catalog")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Country")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime2");
 
                     b.Property<int>("CreditCardSavePolicy")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("DefaultCurrency")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("DefaultLanguage")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Description")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<bool>("DisplayOutOfStock")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Email")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("EmailName")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("FulfillmentCenterId")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Region")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ReturnsFulfillmentCenterId")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("SecureUrl")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<int>("StoreState")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("TimeZone")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Url")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("nvarchar(256)");
 
                     b.HasKey("Id");
 
@@ -346,26 +349,26 @@ namespace VirtoCommerce.StoreModule.Data.PostgreSql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("FulfillmentCenterId")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("StoreId")
                         .IsRequired()
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Type")
                         .IsRequired()
                         .HasMaxLength(32)
-                        .HasColumnType("character varying(32)");
+                        .HasColumnType("nvarchar(32)");
 
                     b.HasKey("Id");
 
@@ -379,16 +382,16 @@ namespace VirtoCommerce.StoreModule.Data.PostgreSql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("LanguageCode")
                         .IsRequired()
                         .HasMaxLength(32)
-                        .HasColumnType("character varying(32)");
+                        .HasColumnType("nvarchar(32)");
 
                     b.Property<string>("StoreId")
                         .IsRequired()
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.HasKey("Id");
 
@@ -402,16 +405,16 @@ namespace VirtoCommerce.StoreModule.Data.PostgreSql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("GroupName")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("StoreId")
                         .IsRequired()
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.HasKey("Id");
 

--- a/src/VirtoCommerce.StoreModule.Data.SqlServer/Migrations/20260714121708_AddStoreAssetPublicUrl.cs
+++ b/src/VirtoCommerce.StoreModule.Data.SqlServer/Migrations/20260714121708_AddStoreAssetPublicUrl.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VirtoCommerce.StoreModule.Data.SqlServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStoreAssetPublicUrl : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AssetPublicUrl",
+                table: "Store",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AssetPublicUrl",
+                table: "Store");
+        }
+    }
+}

--- a/src/VirtoCommerce.StoreModule.Data.SqlServer/Migrations/StoreDbContextModelSnapshot.cs
+++ b/src/VirtoCommerce.StoreModule.Data.SqlServer/Migrations/StoreDbContextModelSnapshot.cs
@@ -17,7 +17,7 @@ namespace VirtoCommerce.StoreModule.Data.SqlServer.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "8.0.11")
+                .HasAnnotation("ProductVersion", "10.0.9")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
@@ -242,6 +242,10 @@ namespace VirtoCommerce.StoreModule.Data.SqlServer.Migrations
                         .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("AdminEmailName")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.Property<string>("AssetPublicUrl")
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
 

--- a/src/VirtoCommerce.StoreModule.Data.SqlServer/Readme.md
+++ b/src/VirtoCommerce.StoreModule.Data.SqlServer/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.1
+dotnet tool install --global dotnet-ef --version 10.0.9
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.1
+dotnet tool update --global dotnet-ef --version 10.0.9
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.StoreModule.Data.SqlServer/VirtoCommerce.StoreModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.StoreModule.Data.SqlServer/VirtoCommerce.StoreModule.Data.SqlServer.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/VirtoCommerce.StoreModule.Data/Model/StoreEntity.cs
+++ b/src/VirtoCommerce.StoreModule.Data/Model/StoreEntity.cs
@@ -22,6 +22,9 @@ namespace VirtoCommerce.StoreModule.Data.Model
         [StringLength(256)]
         public string Url { get; set; }
 
+        [StringLength(256)]
+        public string AssetPublicUrl { get; set; }
+
         public int StoreState { get; set; }
 
         [StringLength(128)]
@@ -118,6 +121,7 @@ namespace VirtoCommerce.StoreModule.Data.Model
             store.SecureUrl = SecureUrl;
             store.TimeZone = TimeZone;
             store.Url = Url;
+            store.AssetPublicUrl = AssetPublicUrl;
             store.MainFulfillmentCenterId = FulfillmentCenterId;
             store.MainReturnsFulfillmentCenterId = ReturnsFulfillmentCenterId;
             store.StoreState = EnumUtility.SafeParse(StoreState.ToString(), Core.Model.StoreState.Open);
@@ -168,6 +172,7 @@ namespace VirtoCommerce.StoreModule.Data.Model
             SecureUrl = store.SecureUrl;
             TimeZone = store.TimeZone;
             Url = store.Url;
+            AssetPublicUrl = store.AssetPublicUrl;
             StoreState = (int)store.StoreState;
 
             if (store.DefaultCurrency != null)
@@ -268,6 +273,7 @@ namespace VirtoCommerce.StoreModule.Data.Model
             target.SecureUrl = SecureUrl;
             target.TimeZone = TimeZone;
             target.Url = Url;
+            target.AssetPublicUrl = AssetPublicUrl;
             target.StoreState = StoreState;
             target.FulfillmentCenterId = FulfillmentCenterId;
             target.ReturnsFulfillmentCenterId = ReturnsFulfillmentCenterId;

--- a/src/VirtoCommerce.StoreModule.Data/Services/StoreAssetPublicUrlResolver.cs
+++ b/src/VirtoCommerce.StoreModule.Data/Services/StoreAssetPublicUrlResolver.cs
@@ -52,6 +52,12 @@ public class StoreAssetPublicUrlResolver : IStoreAssetPublicUrlResolver
             return url;
         }
 
+        // Protocol-relative URLs (//host/path) reference another host; return as-is.
+        if (url.StartsWith("//", StringComparison.Ordinal))
+        {
+            return url;
+        }
+
         if (IsAbsolute(url, out var uri))
         {
             // When known hosts are configured, replace only listed hosts; other hosts are external.
@@ -68,11 +74,20 @@ public class StoreAssetPublicUrlResolver : IStoreAssetPublicUrlResolver
 
     /// <summary>
     /// Combines the store asset base URL (a full URL or bare host, optionally with a base path)
-    /// with a relative asset path.
+    /// with a relative asset path. A query string or fragment in the base URL is ignored so the
+    /// relative path is always appended to the path part.
     /// </summary>
     protected virtual string CombineUrl(string assetPublicUrl, string relativeUrl)
     {
-        return $"{NormalizeBaseUrl(assetPublicUrl).TrimEnd('/')}/{relativeUrl.TrimStart('/')}";
+        var normalizedBase = NormalizeBaseUrl(assetPublicUrl);
+
+        if (Uri.TryCreate(normalizedBase, UriKind.Absolute, out var baseUri) &&
+            (baseUri.Query.Length > 0 || baseUri.Fragment.Length > 0))
+        {
+            normalizedBase = baseUri.GetLeftPart(UriPartial.Path);
+        }
+
+        return $"{normalizedBase.TrimEnd('/')}/{relativeUrl.TrimStart('/')}";
     }
 
     /// <summary>
@@ -95,7 +110,16 @@ public class StoreAssetPublicUrlResolver : IStoreAssetPublicUrlResolver
             }
 
             var basePath = baseUri.AbsolutePath.TrimEnd('/');
-            var combinedPath = basePath + source.AbsolutePath;
+            var sourcePath = source.AbsolutePath;
+
+            // Idempotency: when the URL already points to the asset host and starts with the base path,
+            // don't prepend the base path again (e.g. https://cdn.com/tenant1/assets/x.jpg + https://cdn.com/tenant1).
+            var isAlreadyBased = string.Equals(source.Host, baseUri.Host, StringComparison.OrdinalIgnoreCase) &&
+                (basePath.Length == 0 ||
+                 sourcePath.Equals(basePath, StringComparison.OrdinalIgnoreCase) ||
+                 sourcePath.StartsWith(basePath + "/", StringComparison.OrdinalIgnoreCase));
+
+            var combinedPath = isAlreadyBased ? sourcePath : basePath + sourcePath;
 
             var builder = new UriBuilder
             {

--- a/src/VirtoCommerce.StoreModule.Data/Services/StoreAssetPublicUrlResolver.cs
+++ b/src/VirtoCommerce.StoreModule.Data/Services/StoreAssetPublicUrlResolver.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using VirtoCommerce.StoreModule.Core;
+using VirtoCommerce.StoreModule.Core.Model;
+using VirtoCommerce.StoreModule.Core.Services;
+
+namespace VirtoCommerce.StoreModule.Data.Services;
+
+/// <summary>
+/// Default <see cref="IStoreAssetPublicUrlResolver"/>. When <see cref="Store.AssetPublicUrl"/> is set,
+/// a relative URL is combined with it and an absolute URL is rebased onto it (preserving path, query
+/// and fragment). When <see cref="StoreAssetsOptions.KnownAssetHosts"/> is not empty, only absolute
+/// URLs whose host is listed there are rebased; other hosts are treated as external and returned as-is.
+/// Registered as a singleton.
+/// </summary>
+public class StoreAssetPublicUrlResolver : IStoreAssetPublicUrlResolver
+{
+    // Hosts are compared case-insensitively (StringComparer.OrdinalIgnoreCase).
+    private readonly HashSet<string> _knownAssetHosts;
+    private readonly ILogger<StoreAssetPublicUrlResolver> _logger;
+
+    public StoreAssetPublicUrlResolver(IOptions<StoreAssetsOptions> options, ILogger<StoreAssetPublicUrlResolver> logger)
+    {
+        _logger = logger;
+        _knownAssetHosts = BuildKnownHosts(options.Value.KnownAssetHosts);
+    }
+
+    public virtual string GetAbsoluteUrl(Store store, string url)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+
+        // null/empty is returned as-is
+        if (string.IsNullOrEmpty(url))
+        {
+            return url;
+        }
+
+        // No store override configured => unchanged behavior.
+        var assetPublicUrl = store.AssetPublicUrl;
+        if (string.IsNullOrEmpty(assetPublicUrl))
+        {
+            return url;
+        }
+
+        // data:/blob: are returned as-is
+        if (url.StartsWith("data:", StringComparison.OrdinalIgnoreCase) ||
+            url.StartsWith("blob:", StringComparison.OrdinalIgnoreCase))
+        {
+            return url;
+        }
+
+        if (IsAbsolute(url, out var uri))
+        {
+            // When known hosts are configured, replace only listed hosts; other hosts are external.
+            if (_knownAssetHosts.Count > 0 && !_knownAssetHosts.Contains(uri.Host))
+            {
+                return url;
+            }
+
+            return RebaseHost(assetPublicUrl, url);
+        }
+
+        return CombineUrl(assetPublicUrl, url);
+    }
+
+    /// <summary>
+    /// Combines the store asset base URL (a full URL or bare host, optionally with a base path)
+    /// with a relative asset path.
+    /// </summary>
+    protected virtual string CombineUrl(string assetPublicUrl, string relativeUrl)
+    {
+        return $"{NormalizeBaseUrl(assetPublicUrl).TrimEnd('/')}/{relativeUrl.TrimStart('/')}";
+    }
+
+    /// <summary>
+    /// Replaces scheme/host/port of <paramref name="absoluteUrl"/> with those of
+    /// <paramref name="baseUrl"/> (a full URL or bare host, optionally with a base path),
+    /// preserving the original path, query and fragment.
+    /// On parse failure, logs a warning and returns <paramref name="absoluteUrl"/> unchanged.
+    /// </summary>
+    protected virtual string RebaseHost(string assetPublicUrl, string absoluteUrl)
+    {
+        try
+        {
+            if (!IsAbsolute(absoluteUrl, out var source) ||
+                !Uri.TryCreate(NormalizeBaseUrl(assetPublicUrl), UriKind.Absolute, out var baseUri))
+            {
+                _logger.LogWarning(
+                    "Cannot rebase asset URL '{AssetUrl}' onto the store asset public URL '{AssetPublicUrl}': the base URL is not a valid absolute URL. The original URL is returned as-is.",
+                    absoluteUrl, assetPublicUrl);
+                return absoluteUrl;
+            }
+
+            var basePath = baseUri.AbsolutePath.TrimEnd('/');
+            var combinedPath = basePath + source.AbsolutePath;
+
+            var builder = new UriBuilder
+            {
+                Scheme = baseUri.Scheme,
+                Host = baseUri.Host,
+                Port = baseUri.IsDefaultPort ? -1 : baseUri.Port,
+                Path = combinedPath,
+                Query = source.Query.TrimStart('?'),
+                Fragment = source.Fragment.TrimStart('#'),
+            };
+
+            return builder.Uri.AbsoluteUri;
+        }
+        catch (UriFormatException ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to rebase asset URL '{AssetUrl}' onto the store asset public URL '{AssetPublicUrl}'. The original URL is returned as-is.",
+                absoluteUrl, assetPublicUrl);
+            return absoluteUrl;
+        }
+    }
+
+    private HashSet<string> BuildKnownHosts(IEnumerable<string> knownAssetHosts)
+    {
+        var hosts = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entry in (knownAssetHosts ?? []).Where(x => !string.IsNullOrWhiteSpace(x)))
+        {
+            // Accept a bare host/domain or a full URL.
+            if (Uri.TryCreate(NormalizeBaseUrl(entry.Trim()), UriKind.Absolute, out var uri))
+            {
+                hosts.Add(uri.Host);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Invalid host entry '{KnownAssetHost}' in the {ConfigSection} configuration section. The entry is ignored; expected a bare host (cdn.example.com) or an absolute URL.",
+                    entry, $"{StoreAssetsOptions.SectionName}:{nameof(StoreAssetsOptions.KnownAssetHosts)}");
+            }
+        }
+
+        return hosts;
+    }
+
+    private static string NormalizeBaseUrl(string baseUrl)
+    {
+        return baseUrl.Contains("://", StringComparison.Ordinal) ? baseUrl : $"https://{baseUrl}";
+    }
+
+    private static bool IsAbsolute(string value, out Uri uri)
+    {
+        return Uri.TryCreate(value, UriKind.Absolute, out uri) &&
+               (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+    }
+}

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/de.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/de.VirtoCommerce.Store.json
@@ -6,7 +6,13 @@
         "title": "Shops",
         "labels": {
           "no-stores": "Sie haben noch keine Shops",
-          "name": "Name"
+          "name": "Name",
+          "filter-button-hint": "Filter",
+          "filter-state": "Status",
+          "filter-all": "Alle Status",
+          "filter-open": "Offen",
+          "filter-closed": "Geschlossen",
+          "filter-restricted": "Eingeschränkter Zugriff"
         }
       },
       "store-advanced": {
@@ -26,7 +32,9 @@
           "additional-fulfillment-centers": "Verfügbare Logistikzentren",
           "additional-returns-fulfillment-centers": "Verfügbare Rückgabe-Logistikzentren",
           "operational-timezone": "Betriebszeitzone",
-          "store-url": "Shop-URL"
+          "store-url": "Shop-URL",
+          "store-asset-url": "Asset-URL des Stores",
+          "store-asset-url-hint": "Basis-URL, über die die Asset-URLs (Bilder) dieses Stores in der Experience API bereitgestellt werden, z. B. https://cdn.mystore.com. Überschreibt das globale Asset-CDN. Leer lassen, um den globalen/Admin-Standard zu verwenden."
         },
         "placeholders": {
           "description": "Beschreibung angeben...",
@@ -39,7 +47,8 @@
           "fulfillment-center": "Auswählen...",
           "returns-fulfillment-center": "Auswählen...",
           "operational-timezone": "Auswählen...",
-          "store-url": "URL eingeben"
+          "store-url": "URL eingeben",
+          "store-asset-url": "Asset-Basis-URL eingeben"
         }
       },
       "store-authentication": {
@@ -62,7 +71,9 @@
           "additional-languages": "Zusätzliche Sprachen",
           "default-currency": "Standardwährung",
           "additional-currencies": "Zusätzliche Währungen",
-          "linked-stores": "Verknüpfte Shops (Kunden dieser Shops können ihre Zugangsdaten zur Anmeldung verwenden)"
+          "linked-stores": "Verknüpfte Shops (Kunden dieser Shops können ihre Zugangsdaten zur Anmeldung verwenden)",
+          "urls": "URLs",
+          "hide-description": "Beschreibung ausblenden"
         },
         "placeholders": {
           "code": "Code angeben",
@@ -162,6 +173,11 @@
         "placeholder": "Auswählen...",
         "loading": "Laden..."
       }
+    },
+    "commands": {
+      "copy-code": "Code kopieren",
+      "copy-store-url": "Store-URL kopieren",
+      "open-in-new-window": "In neuem Fenster öffnen"
     }
   },
   "permissions": {

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/en.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/en.VirtoCommerce.Store.json
@@ -1,12 +1,23 @@
 {
   "stores": {
     "main-menu-title": "Stores",
+    "commands": {
+      "copy-code": "Copy code",
+      "copy-store-url": "Copy store URL",
+      "open-in-new-window": "Open in new window"
+    },
     "blades": {
       "stores-list": {
         "title": "Stores",
         "labels": {
           "no-stores": "You have no stores yet",
-          "name": "Name"
+          "name": "Name",
+          "filter-button-hint": "Filters",
+          "filter-state": "State",
+          "filter-all": "All states",
+          "filter-open": "Open",
+          "filter-closed": "Closed",
+          "filter-restricted": "Restricted access"
         }
       },
       "store-advanced": {
@@ -26,7 +37,9 @@
           "additional-fulfillment-centers": "Available fulfillment centers",
           "additional-returns-fulfillment-centers": "Available return fulfillment centers",
           "operational-timezone": "Operation timezone",
-          "store-url": "Store URL"
+          "store-url": "Store URL",
+          "store-asset-url": "Store asset URL",
+          "store-asset-url-hint": "Base URL used to serve this store's asset (image) URLs via the Experience API, e.g. https://cdn.mystore.com. Overrides the global asset CDN. Leave empty to use the global/admin default."
         },
         "placeholders": {
           "description": "Provide description...",
@@ -39,7 +52,8 @@
           "fulfillment-center": "Select...",
           "returns-fulfillment-center": "Select...",
           "operational-timezone": "Select...",
-          "store-url": "Enter URL"
+          "store-url": "Enter URL",
+          "store-asset-url": "Enter asset base URL"
         }
       },
       "store-authentication": {
@@ -58,6 +72,8 @@
           "language": "Language",
           "currency": "Currency",
           "links": "Links",
+          "urls": "URLs",
+          "hide-description": "Hide description",
           "default-language": "Default language",
           "additional-languages": "Additional languages",
           "default-currency": "Default currency",

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/es.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/es.VirtoCommerce.Store.json
@@ -6,7 +6,13 @@
         "title": "Tiendas",
         "labels": {
           "no-stores": "No tienes tiendas aún",
-          "name": "Nombre"
+          "name": "Nombre",
+          "filter-button-hint": "Filtros",
+          "filter-state": "Estado",
+          "filter-all": "Todos los estados",
+          "filter-open": "Abierta",
+          "filter-closed": "Cerrada",
+          "filter-restricted": "Acceso restringido"
         }
       },
       "store-advanced": {
@@ -26,7 +32,9 @@
           "additional-fulfillment-centers": "Centros de cumplimiento disponibles",
           "additional-returns-fulfillment-centers": "Centros de devoluciones disponibles",
           "operational-timezone": "Zona horaria de operación",
-          "store-url": "URL de la tienda"
+          "store-url": "URL de la tienda",
+          "store-asset-url": "URL de activos de la tienda",
+          "store-asset-url-hint": "URL base utilizada para servir las URL de los activos (imágenes) de esta tienda a través de la Experience API, p. ej. https://cdn.mystore.com. Sobrescribe el CDN de activos global. Déjela vacía para usar el valor global/predeterminado."
         },
         "placeholders": {
           "description": "Proporcionar descripción...",
@@ -39,7 +47,8 @@
           "fulfillment-center": "Seleccionar...",
           "returns-fulfillment-center": "Seleccionar...",
           "operational-timezone": "Seleccionar...",
-          "store-url": "Ingresar URL"
+          "store-url": "Ingresar URL",
+          "store-asset-url": "Introducir URL base de activos"
         }
       },
       "store-authentication": {
@@ -62,7 +71,9 @@
           "additional-languages": "Idiomas adicionales",
           "default-currency": "Moneda predeterminada",
           "additional-currencies": "Monedas adicionales",
-          "linked-stores": "Tiendas vinculadas (los clientes de estas tiendas pueden usar sus credenciales para iniciar sesión)"
+          "linked-stores": "Tiendas vinculadas (los clientes de estas tiendas pueden usar sus credenciales para iniciar sesión)",
+          "urls": "URLs",
+          "hide-description": "Ocultar descripción"
         },
         "placeholders": {
           "code": "Proporcionar código",
@@ -162,6 +173,11 @@
         "placeholder": "Seleccionar...",
         "loading": "Cargando..."
       }
+    },
+    "commands": {
+      "copy-code": "Copiar código",
+      "copy-store-url": "Copiar URL de la tienda",
+      "open-in-new-window": "Abrir en una nueva ventana"
     }
   },
   "permissions": {

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/fi.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/fi.VirtoCommerce.Store.json
@@ -6,7 +6,13 @@
         "title": "Kaupat",
         "labels": {
           "no-stores": "Sinulla ei ole vielä kauppoja",
-          "name": "Nimi"
+          "name": "Nimi",
+          "filter-button-hint": "Suodattimet",
+          "filter-state": "Tila",
+          "filter-all": "Kaikki tilat",
+          "filter-open": "Avoinna",
+          "filter-closed": "Suljettu",
+          "filter-restricted": "Rajoitettu pääsy"
         }
       },
       "store-advanced": {
@@ -26,7 +32,9 @@
           "additional-fulfillment-centers": "Käytettävissä olevat jakelukeskukset",
           "additional-returns-fulfillment-centers": "Käytettävissä olevat palautusjakelukeskukset",
           "operational-timezone": "Toiminta-ajanvyöhyke",
-          "store-url": "Kaupan URL"
+          "store-url": "Kaupan URL",
+          "store-asset-url": "Kaupan resurssien URL-osoite",
+          "store-asset-url-hint": "Perus-URL, jota käytetään tämän kaupan resurssien (kuvien) URL-osoitteiden muodostamiseen Experience API:ssa, esim. https://cdn.mystore.com. Ohittaa globaalin resurssi-CDN:n. Jätä tyhjäksi käyttääksesi globaalia/oletusarvoa."
         },
         "placeholders": {
           "description": "Anna kuvaus...",
@@ -39,7 +47,8 @@
           "fulfillment-center": "Valitse...",
           "returns-fulfillment-center": "Valitse...",
           "operational-timezone": "Valitse...",
-          "store-url": "Syötä URL"
+          "store-url": "Syötä URL",
+          "store-asset-url": "Syötä resurssien perus-URL"
         }
       },
       "store-authentication": {
@@ -62,7 +71,9 @@
           "additional-languages": "Lisäkieli",
           "default-currency": "Oletusvaluutta",
           "additional-currencies": "Lisävaluutat",
-          "linked-stores": "Linkitetyt kaupat (asiakkaat näistä kaupoista voivat käyttää tunnuksiaan kirjautumiseen)"
+          "linked-stores": "Linkitetyt kaupat (asiakkaat näistä kaupoista voivat käyttää tunnuksiaan kirjautumiseen)",
+          "urls": "URL-osoitteet",
+          "hide-description": "Piilota kuvaus"
         },
         "placeholders": {
           "code": "Anna koodi",
@@ -162,6 +173,11 @@
         "placeholder": "Valitse...",
         "loading": "Ladataan..."
       }
+    },
+    "commands": {
+      "copy-code": "Kopioi koodi",
+      "copy-store-url": "Kopioi kaupan URL-osoite",
+      "open-in-new-window": "Avaa uudessa ikkunassa"
     }
   },
   "permissions": {

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/fr.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/fr.VirtoCommerce.Store.json
@@ -6,7 +6,13 @@
         "title": "Magasins",
         "labels": {
           "no-stores": "Vous n'avez pas encore de magasins",
-          "name": "Nom"
+          "name": "Nom",
+          "filter-button-hint": "Filtres",
+          "filter-state": "État",
+          "filter-all": "Tous les états",
+          "filter-open": "Ouverte",
+          "filter-closed": "Fermée",
+          "filter-restricted": "Accès restreint"
         }
       },
       "store-advanced": {
@@ -26,7 +32,9 @@
           "additional-fulfillment-centers": "Centres de traitement disponibles",
           "additional-returns-fulfillment-centers": "Centres de retour disponibles",
           "operational-timezone": "Fuseau horaire opérationnel",
-          "store-url": "URL du magasin"
+          "store-url": "URL du magasin",
+          "store-asset-url": "URL des ressources de la boutique",
+          "store-asset-url-hint": "URL de base utilisée pour servir les URL des ressources (images) de cette boutique via l'Experience API, p. ex. https://cdn.mystore.com. Remplace le CDN de ressources global. Laisser vide pour utiliser la valeur globale/par défaut."
         },
         "placeholders": {
           "description": "Fournir une description...",
@@ -39,7 +47,8 @@
           "fulfillment-center": "Sélectionner...",
           "returns-fulfillment-center": "Sélectionner...",
           "operational-timezone": "Sélectionner...",
-          "store-url": "Entrer l'URL"
+          "store-url": "Entrer l'URL",
+          "store-asset-url": "Saisir l'URL de base des ressources"
         }
       },
       "store-authentication": {
@@ -62,7 +71,9 @@
           "additional-languages": "Langues supplémentaires",
           "default-currency": "Devise par défaut",
           "additional-currencies": "Devises supplémentaires",
-          "linked-stores": "Boutiques liées (les clients de ces boutiques peuvent utiliser leurs identifiants pour se connecter)"
+          "linked-stores": "Boutiques liées (les clients de ces boutiques peuvent utiliser leurs identifiants pour se connecter)",
+          "urls": "URLs",
+          "hide-description": "Masquer la description"
         },
         "placeholders": {
           "code": "Fournir un code",
@@ -162,6 +173,11 @@
         "placeholder": "Sélectionner...",
         "loading": "Chargement..."
       }
+    },
+    "commands": {
+      "copy-code": "Copier le code",
+      "copy-store-url": "Copier l'URL de la boutique",
+      "open-in-new-window": "Ouvrir dans une nouvelle fenêtre"
     }
   },
   "permissions": {

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/it.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/it.VirtoCommerce.Store.json
@@ -6,7 +6,13 @@
         "title": "Negozi",
         "labels": {
           "no-stores": "Non hai ancora negozi",
-          "name": "Nome"
+          "name": "Nome",
+          "filter-button-hint": "Filtri",
+          "filter-state": "Stato",
+          "filter-all": "Tutti gli stati",
+          "filter-open": "Aperto",
+          "filter-closed": "Chiuso",
+          "filter-restricted": "Accesso limitato"
         }
       },
       "store-advanced": {
@@ -26,7 +32,9 @@
           "additional-fulfillment-centers": "Centri di evasione disponibili",
           "additional-returns-fulfillment-centers": "Centri di restituzione disponibili",
           "operational-timezone": "Fuso orario operativo",
-          "store-url": "URL del negozio"
+          "store-url": "URL del negozio",
+          "store-asset-url": "URL delle risorse del negozio",
+          "store-asset-url-hint": "URL di base utilizzato per servire gli URL delle risorse (immagini) di questo negozio tramite l'Experience API, ad es. https://cdn.mystore.com. Sostituisce la CDN globale delle risorse. Lasciare vuoto per usare il valore globale/predefinito."
         },
         "placeholders": {
           "description": "Fornire descrizione...",
@@ -39,7 +47,8 @@
           "fulfillment-center": "Selezionare...",
           "returns-fulfillment-center": "Selezionare...",
           "operational-timezone": "Selezionare...",
-          "store-url": "Inserire URL"
+          "store-url": "Inserire URL",
+          "store-asset-url": "Inserisci l'URL di base delle risorse"
         }
       },
       "store-authentication": {
@@ -62,7 +71,9 @@
           "additional-languages": "Lingue aggiuntive",
           "default-currency": "Valuta predefinita",
           "additional-currencies": "Valute aggiuntive",
-          "linked-stores": "Negozi collegati (i clienti di questi negozi possono utilizzare le proprie credenziali per accedere)"
+          "linked-stores": "Negozi collegati (i clienti di questi negozi possono utilizzare le proprie credenziali per accedere)",
+          "urls": "URL",
+          "hide-description": "Nascondi descrizione"
         },
         "placeholders": {
           "code": "Fornire codice",
@@ -162,6 +173,11 @@
         "placeholder": "Selezionare...",
         "loading": "Caricamento..."
       }
+    },
+    "commands": {
+      "copy-code": "Copia codice",
+      "copy-store-url": "Copia URL del negozio",
+      "open-in-new-window": "Apri in una nuova finestra"
     }
   },
   "permissions": {

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/ja.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/ja.VirtoCommerce.Store.json
@@ -6,7 +6,13 @@
         "title": "ストア",
         "labels": {
           "no-stores": "まだストアはありません",
-          "name": "名前"
+          "name": "名前",
+          "filter-button-hint": "フィルター",
+          "filter-state": "状態",
+          "filter-all": "すべての状態",
+          "filter-open": "オープン",
+          "filter-closed": "クローズ",
+          "filter-restricted": "アクセス制限"
         }
       },
       "store-advanced": {
@@ -26,7 +32,9 @@
           "additional-fulfillment-centers": "利用可能なフルフィルメントセンター",
           "additional-returns-fulfillment-centers": "利用可能な返品フルフィルメントセンター",
           "operational-timezone": "運用タイムゾーン",
-          "store-url": "ストアのURL"
+          "store-url": "ストアのURL",
+          "store-asset-url": "ストアアセットURL",
+          "store-asset-url-hint": "Experience API でこのストアのアセット（画像）URL を提供するためのベース URL（例: https://cdn.mystore.com）。グローバルのアセット CDN を上書きします。空の場合はグローバル/管理者のデフォルトが使用されます。"
         },
         "placeholders": {
           "description": "説明を提供...",
@@ -39,7 +47,8 @@
           "fulfillment-center": "選択...",
           "returns-fulfillment-center": "選択...",
           "operational-timezone": "選択...",
-          "store-url": "URLを入力"
+          "store-url": "URLを入力",
+          "store-asset-url": "アセットのベースURLを入力"
         }
       },
       "store-authentication": {
@@ -62,7 +71,9 @@
           "additional-languages": "追加の言語",
           "default-currency": "デフォルトの通貨",
           "additional-currencies": "追加の通貨",
-          "linked-stores": "連携ストア（これらのストアの顧客は自分の認証情報でサインインできます）"
+          "linked-stores": "連携ストア（これらのストアの顧客は自分の認証情報でサインインできます）",
+          "urls": "URL",
+          "hide-description": "説明を隠す"
         },
         "placeholders": {
           "code": "コードを提供",
@@ -162,6 +173,11 @@
         "placeholder": "選択...",
         "loading": "読み込み中..."
       }
+    },
+    "commands": {
+      "copy-code": "コードをコピー",
+      "copy-store-url": "ストアURLをコピー",
+      "open-in-new-window": "新しいウィンドウで開く"
     }
   },
   "permissions": {

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/no.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/no.VirtoCommerce.Store.json
@@ -6,7 +6,13 @@
         "title": "Butikker",
         "labels": {
           "no-stores": "Du har ingen butikker ennå",
-          "name": "Navn"
+          "name": "Navn",
+          "filter-button-hint": "Filtre",
+          "filter-state": "Status",
+          "filter-all": "Alle statuser",
+          "filter-open": "Åpen",
+          "filter-closed": "Stengt",
+          "filter-restricted": "Begrenset tilgang"
         }
       },
       "store-advanced": {
@@ -26,7 +32,9 @@
           "additional-fulfillment-centers": "Tilgjengelige oppfyllelsessentre",
           "additional-returns-fulfillment-centers": "Tilgjengelige retur-oppfyllelsessentre",
           "operational-timezone": "Operasjonell tidssone",
-          "store-url": "Butikkens URL"
+          "store-url": "Butikkens URL",
+          "store-asset-url": "Butikkens ressurs-URL",
+          "store-asset-url-hint": "Basis-URL som brukes til å levere denne butikkens ressurs-URL-er (bilder) via Experience API, f.eks. https://cdn.mystore.com. Overstyrer den globale ressurs-CDN-en. La stå tom for å bruke global/standardverdi."
         },
         "placeholders": {
           "description": "Gi en beskrivelse...",
@@ -39,7 +47,8 @@
           "fulfillment-center": "Velg...",
           "returns-fulfillment-center": "Velg...",
           "operational-timezone": "Velg...",
-          "store-url": "Skriv inn URL"
+          "store-url": "Skriv inn URL",
+          "store-asset-url": "Angi basis-URL for ressurser"
         }
       },
       "store-authentication": {
@@ -62,7 +71,9 @@
           "additional-languages": "Tilleggsspråk",
           "default-currency": "Standardvaluta",
           "additional-currencies": "Tilleggsvalutaer",
-          "linked-stores": "Koblede butikker (kunder fra disse butikkene kan bruke sine innloggingsdetaljer for å logge inn)"
+          "linked-stores": "Koblede butikker (kunder fra disse butikkene kan bruke sine innloggingsdetaljer for å logge inn)",
+          "urls": "URL-er",
+          "hide-description": "Skjul beskrivelse"
         },
         "placeholders": {
           "code": "Angi kode",
@@ -162,6 +173,11 @@
         "placeholder": "Velg...",
         "loading": "Laster..."
       }
+    },
+    "commands": {
+      "copy-code": "Kopier kode",
+      "copy-store-url": "Kopier butikk-URL",
+      "open-in-new-window": "Åpne i nytt vindu"
     }
   },
   "permissions": {

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/pl.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/pl.VirtoCommerce.Store.json
@@ -6,7 +6,13 @@
         "title": "Sklepy",
         "labels": {
           "no-stores": "Nie masz jeszcze żadnych sklepów",
-          "name": "Nazwa"
+          "name": "Nazwa",
+          "filter-button-hint": "Filtry",
+          "filter-state": "Stan",
+          "filter-all": "Wszystkie stany",
+          "filter-open": "Otwarty",
+          "filter-closed": "Zamknięty",
+          "filter-restricted": "Dostęp ograniczony"
         }
       },
       "store-advanced": {
@@ -26,7 +32,9 @@
           "additional-fulfillment-centers": "Dostępne centra realizacji",
           "additional-returns-fulfillment-centers": "Dostępne centra zwrotów",
           "operational-timezone": "Strefa czasowa operacyjna",
-          "store-url": "URL sklepu"
+          "store-url": "URL sklepu",
+          "store-asset-url": "Adres URL zasobów sklepu",
+          "store-asset-url-hint": "Bazowy adres URL używany do udostępniania adresów URL zasobów (obrazów) tego sklepu przez Experience API, np. https://cdn.mystore.com. Zastępuje globalny CDN zasobów. Pozostaw puste, aby użyć wartości globalnej/domyślnej."
         },
         "placeholders": {
           "description": "Podaj opis...",
@@ -39,7 +47,8 @@
           "fulfillment-center": "Wybierz...",
           "returns-fulfillment-center": "Wybierz...",
           "operational-timezone": "Wybierz...",
-          "store-url": "Wprowadź URL"
+          "store-url": "Wprowadź URL",
+          "store-asset-url": "Wprowadź bazowy adres URL zasobów"
         }
       },
       "store-authentication": {
@@ -62,7 +71,9 @@
           "additional-languages": "Dodatkowe języki",
           "default-currency": "Waluta domyślna",
           "additional-currencies": "Dodatkowe waluty",
-          "linked-stores": "Powiązane sklepy (klienci tych sklepów mogą używać swoich danych logowania do zalogowania się)"
+          "linked-stores": "Powiązane sklepy (klienci tych sklepów mogą używać swoich danych logowania do zalogowania się)",
+          "urls": "Adresy URL",
+          "hide-description": "Ukryj opis"
         },
         "placeholders": {
           "code": "Podaj kod",
@@ -162,6 +173,11 @@
         "placeholder": "Wybierz...",
         "loading": "Ładowanie..."
       }
+    },
+    "commands": {
+      "copy-code": "Kopiuj kod",
+      "copy-store-url": "Kopiuj adres URL sklepu",
+      "open-in-new-window": "Otwórz w nowym oknie"
     }
   },
   "permissions": {

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/pt.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/pt.VirtoCommerce.Store.json
@@ -6,7 +6,13 @@
         "title": "Lojas",
         "labels": {
           "no-stores": "Você ainda não tem lojas",
-          "name": "Nome"
+          "name": "Nome",
+          "filter-button-hint": "Filtros",
+          "filter-state": "Estado",
+          "filter-all": "Todos os estados",
+          "filter-open": "Aberta",
+          "filter-closed": "Fechada",
+          "filter-restricted": "Acesso restrito"
         }
       },
       "store-advanced": {
@@ -26,7 +32,9 @@
           "additional-fulfillment-centers": "Centros de atendimento disponíveis",
           "additional-returns-fulfillment-centers": "Centros de devolução disponíveis",
           "operational-timezone": "Fuso horário operacional",
-          "store-url": "URL da loja"
+          "store-url": "URL da loja",
+          "store-asset-url": "URL de ativos da loja",
+          "store-asset-url-hint": "URL base usada para servir as URLs dos ativos (imagens) desta loja via Experience API, por ex. https://cdn.mystore.com. Substitui o CDN global de ativos. Deixe vazio para usar o padrão global/administrativo."
         },
         "placeholders": {
           "description": "Fornecer descrição...",
@@ -39,7 +47,8 @@
           "fulfillment-center": "Selecionar...",
           "returns-fulfillment-center": "Selecionar...",
           "operational-timezone": "Selecionar...",
-          "store-url": "Inserir URL"
+          "store-url": "Inserir URL",
+          "store-asset-url": "Inserir URL base de ativos"
         }
       },
       "store-authentication": {
@@ -62,7 +71,9 @@
           "additional-languages": "Idiomas adicionais",
           "default-currency": "Moeda padrão",
           "additional-currencies": "Moedas adicionais",
-          "linked-stores": "Lojas vinculadas (clientes dessas lojas podem usar suas credenciais para fazer login)"
+          "linked-stores": "Lojas vinculadas (clientes dessas lojas podem usar suas credenciais para fazer login)",
+          "urls": "URLs",
+          "hide-description": "Ocultar descrição"
         },
         "placeholders": {
           "code": "Fornecer código",
@@ -162,6 +173,11 @@
         "placeholder": "Selecionar...",
         "loading": "Carregando..."
       }
+    },
+    "commands": {
+      "copy-code": "Copiar código",
+      "copy-store-url": "Copiar URL da loja",
+      "open-in-new-window": "Abrir em nova janela"
     }
   },
   "permissions": {

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/ru.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/ru.VirtoCommerce.Store.json
@@ -6,7 +6,13 @@
         "title": "Магазины",
         "labels": {
           "no-stores": "У вас пока нет магазинов",
-          "name": "Имя"
+          "name": "Имя",
+          "filter-button-hint": "Фильтры",
+          "filter-state": "Состояние",
+          "filter-all": "Все состояния",
+          "filter-open": "Открыт",
+          "filter-closed": "Закрыт",
+          "filter-restricted": "Ограниченный доступ"
         }
       },
       "store-advanced": {
@@ -26,7 +32,9 @@
           "additional-fulfillment-centers": "Доступные центры выполнения заказов",
           "additional-returns-fulfillment-centers": "Доступные центры выполнения возврата",
           "operational-timezone": "Часовой пояс работы",
-          "store-url": "URL магазина"
+          "store-url": "URL магазина",
+          "store-asset-url": "URL ресурсов магазина",
+          "store-asset-url-hint": "Базовый URL, по которому через Experience API отдаются URL ресурсов (изображений) этого магазина, напр. https://cdn.mystore.com. Переопределяет глобальный CDN ресурсов. Оставьте пустым, чтобы использовать глобальное значение по умолчанию."
         },
         "placeholders": {
           "description": "Укажите описание...",
@@ -39,7 +47,8 @@
           "fulfillment-center": "Выберите...",
           "returns-fulfillment-center": "Выберите...",
           "operational-timezone": "Выберите...",
-          "store-url": "Введите URL"
+          "store-url": "Введите URL",
+          "store-asset-url": "Введите базовый URL ресурсов"
         }
       },
       "store-authentication": {
@@ -62,7 +71,9 @@
           "additional-languages": "Дополнительные языки",
           "default-currency": "Валюта по умолчанию",
           "additional-currencies": "Дополнительные валюты",
-          "linked-stores": "Связанные магазины (клиенты этих магазинов могут использовать свои учетные данные для входа)"
+          "linked-stores": "Связанные магазины (клиенты этих магазинов могут использовать свои учетные данные для входа)",
+          "urls": "URL-адреса",
+          "hide-description": "Скрыть описание"
         },
         "placeholders": {
           "code": "Укажите код",
@@ -162,6 +173,11 @@
         "placeholder": "Выберите...",
         "loading": "Загрузка..."
       }
+    },
+    "commands": {
+      "copy-code": "Копировать код",
+      "copy-store-url": "Копировать URL магазина",
+      "open-in-new-window": "Открыть в новом окне"
     }
   },
   "permissions": {

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/sv.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/sv.VirtoCommerce.Store.json
@@ -6,7 +6,13 @@
         "title": "Butiker",
         "labels": {
           "no-stores": "Du har inga butiker ännu",
-          "name": "Namn"
+          "name": "Namn",
+          "filter-button-hint": "Filter",
+          "filter-state": "Status",
+          "filter-all": "Alla statusar",
+          "filter-open": "Öppen",
+          "filter-closed": "Stängd",
+          "filter-restricted": "Begränsad åtkomst"
         }
       },
       "store-advanced": {
@@ -26,7 +32,9 @@
           "additional-fulfillment-centers": "Tillgängliga distributionscenter",
           "additional-returns-fulfillment-centers": "Tillgängliga returcenter",
           "operational-timezone": "Operativ tidszon",
-          "store-url": "Butikens URL"
+          "store-url": "Butikens URL",
+          "store-asset-url": "Butikens resurs-URL",
+          "store-asset-url-hint": "Bas-URL som används för att leverera denna butiks resurs-URL:er (bilder) via Experience API, t.ex. https://cdn.mystore.com. Åsidosätter den globala resurs-CDN:en. Lämna tomt för att använda globalt/standardvärde."
         },
         "placeholders": {
           "description": "Ange beskrivning...",
@@ -39,7 +47,8 @@
           "fulfillment-center": "Välj...",
           "returns-fulfillment-center": "Välj...",
           "operational-timezone": "Välj...",
-          "store-url": "Ange URL"
+          "store-url": "Ange URL",
+          "store-asset-url": "Ange bas-URL för resurser"
         }
       },
       "store-authentication": {
@@ -62,7 +71,9 @@
           "additional-languages": "Ytterligare språk",
           "default-currency": "Standardvaluta",
           "additional-currencies": "Ytterligare valutor",
-          "linked-stores": "Länkade butiker (kunder från dessa butiker kan använda sina inloggningsuppgifter för att logga in)"
+          "linked-stores": "Länkade butiker (kunder från dessa butiker kan använda sina inloggningsuppgifter för att logga in)",
+          "urls": "URL:er",
+          "hide-description": "Dölj beskrivning"
         },
         "placeholders": {
           "code": "Ange kod",
@@ -162,6 +173,11 @@
         "placeholder": "Välj...",
         "loading": "Laddar..."
       }
+    },
+    "commands": {
+      "copy-code": "Kopiera kod",
+      "copy-store-url": "Kopiera butikens URL",
+      "open-in-new-window": "Öppna i nytt fönster"
     }
   },
   "permissions": {

--- a/src/VirtoCommerce.StoreModule.Web/Localizations/zh.VirtoCommerce.Store.json
+++ b/src/VirtoCommerce.StoreModule.Web/Localizations/zh.VirtoCommerce.Store.json
@@ -6,7 +6,13 @@
         "title": "商店",
         "labels": {
           "no-stores": "您还没有商店",
-          "name": "名称"
+          "name": "名称",
+          "filter-button-hint": "筛选",
+          "filter-state": "状态",
+          "filter-all": "所有状态",
+          "filter-open": "开放",
+          "filter-closed": "关闭",
+          "filter-restricted": "受限访问"
         }
       },
       "store-advanced": {
@@ -26,7 +32,9 @@
           "additional-fulfillment-centers": "可用履行中心",
           "additional-returns-fulfillment-centers": "可用退货履行中心",
           "operational-timezone": "操作时区",
-          "store-url": "商店网址"
+          "store-url": "商店网址",
+          "store-asset-url": "商店资源URL",
+          "store-asset-url-hint": "通过 Experience API 提供本商店资源（图片）URL 所使用的基础 URL，例如 https://cdn.mystore.com。会覆盖全局资源 CDN。留空则使用全局/默认值。"
         },
         "placeholders": {
           "description": "提供描述...",
@@ -39,7 +47,8 @@
           "fulfillment-center": "选择...",
           "returns-fulfillment-center": "选择...",
           "operational-timezone": "选择...",
-          "store-url": "输入网址"
+          "store-url": "输入网址",
+          "store-asset-url": "输入资源基础URL"
         }
       },
       "store-authentication": {
@@ -62,7 +71,9 @@
           "additional-languages": "附加语言",
           "default-currency": "默认货币",
           "additional-currencies": "附加货币",
-          "linked-stores": "关联商店（这些商店的客户可以使用其凭证登录）"
+          "linked-stores": "关联商店（这些商店的客户可以使用其凭证登录）",
+          "urls": "URL",
+          "hide-description": "隐藏描述"
         },
         "placeholders": {
           "code": "提供代码",
@@ -162,6 +173,11 @@
         "placeholder": "选择...",
         "loading": "加载中..."
       }
+    },
+    "commands": {
+      "copy-code": "复制代码",
+      "copy-store-url": "复制商店URL",
+      "open-in-new-window": "在新窗口中打开"
     }
   },
   "permissions": {

--- a/src/VirtoCommerce.StoreModule.Web/Module.cs
+++ b/src/VirtoCommerce.StoreModule.Web/Module.cs
@@ -81,6 +81,9 @@ namespace VirtoCommerce.StoreModule.Web
             serviceCollection.AddTransient<IStoreAuthenticationService, StoreAuthenticationService>();
             serviceCollection.AddTransient<IStoreAuthenticationSchemeService, StoreAuthenticationSchemeService>();
             serviceCollection.AddTransient<IStoreAuthenticationSchemeSearchService, StoreAuthenticationSchemeSearchService>();
+
+            serviceCollection.AddOptions<StoreAssetsOptions>().Bind(Configuration.GetSection(StoreAssetsOptions.SectionName));
+            serviceCollection.AddSingleton<IStoreAssetPublicUrlResolver, StoreAssetPublicUrlResolver>();
         }
 
         public void PostInitialize(IApplicationBuilder appBuilder)

--- a/src/VirtoCommerce.StoreModule.Web/Scripts/blades/store-detail.tpl.html
+++ b/src/VirtoCommerce.StoreModule.Web/Scripts/blades/store-detail.tpl.html
@@ -44,6 +44,25 @@
                         </div>
                     </div>
                 </div>
+                <fieldset>
+                    <legend>{{ 'stores.blades.store-detail.labels.urls' | translate }}</legend>
+                </fieldset>
+                <div class="form-group">
+                    <label class="form-label">{{ 'stores.blades.store-advanced.labels.store-url' | translate }}</label>
+                    <div class="form-input">
+                        <input ng-model="blade.currentEntity.url" type="url" placeholder="{{ 'stores.blades.store-advanced.placeholders.store-url' | translate }}">
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label class="form-label">{{ 'stores.blades.store-advanced.labels.store-asset-url' | translate }} <i class="form-ico fa fa-question-circle __link __lightblue" ng-click="blade.assetPublicUrl_descrVisible=!blade.assetPublicUrl_descrVisible"></i></label>
+                    <div class="form-input">
+                        <input ng-model="blade.currentEntity.assetPublicUrl" type="url" placeholder="{{ 'stores.blades.store-advanced.placeholders.store-asset-url' | translate }}">
+                    </div>
+                    <div ng-if="blade.assetPublicUrl_descrVisible">
+                        <div class="list __info list-descr">{{ 'stores.blades.store-advanced.labels.store-asset-url-hint' | translate }}</div>
+                        <a href="" ng-click="blade.assetPublicUrl_descrVisible = null;">{{ 'stores.blades.store-detail.labels.hide-description' | translate }}</a>
+                    </div>
+                </div>
                 <div class="form-group clearfix">
                     <fieldset>
                         <legend>{{ 'stores.blades.store-detail.labels.language' | translate }}</legend>
@@ -113,17 +132,6 @@
                     <label class="form-label">{{ 'stores.blades.store-detail.labels.linked-stores' | translate }}</label>
                     <div class="form-input" data-role="input-control">
                         <va-store-selector multiple ng-model="blade.currentEntity.trustedGroups" stores-to-hide="[blade.currentEntity.id]" placeholder="'stores.blades.store-detail.placeholders.linked-stores'"></va-store-selector>
-                    </div>
-                </div>
-
-                <div class="form-group clearfix">
-                    <div class="column">
-                        <div class="form-group">
-                            <label class="form-label">{{ 'stores.blades.store-advanced.labels.store-url' | translate }}</label>
-                            <div class="form-input">
-                                <input ng-model="blade.currentEntity.url" type="url" placeholder="{{ 'stores.blades.store-advanced.placeholders.store-url' | translate }}">
-                            </div>
-                        </div>
                     </div>
                 </div>
 

--- a/src/VirtoCommerce.StoreModule.Web/Scripts/blades/stores-list.js
+++ b/src/VirtoCommerce.StoreModule.Web/Scripts/blades/stores-list.js
@@ -10,6 +10,7 @@ angular.module('virtoCommerce.storeModule')
             blade.isLoading = true;
             stores.search({
                 keyword: filter.keyword ? filter.keyword : undefined,
+                storeStates: filter.storeState ? [filter.storeState] : undefined,
                 sort: uiGridHelper.getSortExpression($scope),
                 skip: ($scope.pageSettings.currentPage - 1) * $scope.pageSettings.itemsPerPageCount,
                 take: $scope.pageSettings.itemsPerPageCount
@@ -35,6 +36,18 @@ angular.module('virtoCommerce.storeModule')
             };
             bladeNavigationService.showBlade(newBlade, blade);
         }
+
+        $scope.copyText = function (text) {
+            if (text) {
+                navigator.clipboard.writeText(text).then().catch(e => console.error(e));
+            }
+        };
+
+        $scope.openStoreInNewWindow = function (data) {
+            if (data.url) {
+                window.open(data.url, '_blank');
+            }
+        };
 
         function openBladeNew() {
             $scope.selectedNodeId = null;
@@ -71,7 +84,23 @@ angular.module('virtoCommerce.storeModule')
         ];
 
         // simple and advanced filtering
-        var filter = $scope.filter = {};
+        var filter = $scope.filter = { storeState: '' };
+
+        $scope.stateFilters = [
+            { name: 'stores.blades.stores-list.labels.filter-all', value: '' },
+            { name: 'stores.blades.stores-list.labels.filter-open', value: 'Open' },
+            { name: 'stores.blades.stores-list.labels.filter-closed', value: 'Closed' },
+            { name: 'stores.blades.stores-list.labels.filter-restricted', value: 'RestrictedAccess' }
+        ];
+
+        filter.hasActiveFilters = function () {
+            return !!filter.storeState;
+        };
+
+        filter.clearFilters = function () {
+            filter.storeState = '';
+            filter.criteriaChanged();
+        };
 
         filter.criteriaChanged = function () {
             if ($scope.pageSettings.currentPage > 1) {
@@ -80,6 +109,12 @@ angular.module('virtoCommerce.storeModule')
                 blade.refresh();
             }
         };
+
+        $scope.$watch('filter.keyword', function (newVal, oldVal) {
+            if (newVal !== oldVal) {
+                filter.criteriaChanged();
+            }
+        });
 
         // ui-grid
         $scope.setGridOptions = function (gridOptions) {

--- a/src/VirtoCommerce.StoreModule.Web/Scripts/blades/stores-list.tpl.html
+++ b/src/VirtoCommerce.StoreModule.Web/Scripts/blades/stores-list.tpl.html
@@ -1,28 +1,47 @@
 <div class="blade-static">
-    <div class="form-group">
-        <div class="form-input __search">
-            <input placeholder="{{'platform.placeholders.search-keyword' | translate}}" ng-model="filter.keyword" ng-keyup="$event.which === 13 && filter.criteriaChanged()" />
-            <button class="btn __other" style="position: relative;right: 45px;">
-                <i class="btn-ico fa fa-times-circle" title="Clear" ng-click="filter.keyword=null;filter.criteriaChanged()"></i>
-            </button>
-        </div>
+    <div class="form-group" style="display: flex; align-items: center;">
+        <va-filter-panel
+            has-active-filters="filter.hasActiveFilters()"
+            on-clear-filters="filter.clearFilters()"
+            search-text="filter.keyword"
+            filter-title="{{ 'stores.blades.stores-list.labels.filter-button-hint' | translate }}">
+
+            <div class="va-filter-panel__row">
+                <span class="va-filter-panel__label">{{ 'stores.blades.stores-list.labels.filter-state' | translate }}</span>
+                <select class="va-filter-panel__select"
+                        ng-model="filter.storeState"
+                        ng-change="filter.criteriaChanged()"
+                        ng-options="s.value as (s.name | translate) for s in stateFilters">
+                </select>
+            </div>
+        </va-filter-panel>
     </div>
 </div>
 <div class="blade-static __bottom" ng-if="pageSettings.itemsPerPageCount < pageSettings.totalItems" ng-include="'pagerTemplate.html'"></div>
-<div class="blade-content">
+<div class="blade-content __medium-wide">
     <div class="blade-inner">
         <div class="inner-block">
             <div class="table-wrapper" ng-init="setGridOptions({
                     useExternalSorting: true,
                     rowTemplate: 'list.row.html',
+                    rowHeight: 60,
                     columnDefs: [
                                 { name: 'actions', displayName: '', enableColumnResizing: false, enableSorting: false, width: 30, cellTemplate: 'list-actions.cell.html', pinnedLeft:true },
-                                { name: 'name', displayName: 'stores.blades.stores-list.labels.name', sort: { direction: uiGridConstants.ASC }}
+                                { name: 'name', displayName: 'stores.blades.stores-list.labels.name', sort: { direction: uiGridConstants.ASC }, cellTemplate: 'list-name.cell.html' }
                         ]})">
                 <div ui-grid="gridOptions" ui-grid-auto-resize ui-grid-save-state ui-grid-resize-columns ui-grid-move-columns ui-grid-pinning ui-grid-height></div>
                 <ul class="menu __context" role="menu" id="sto_menu">
                     <li class="menu-item" ng-click='blade.selectNode(contextMenuEntity)'>
                         <i class="menu-ico fa fa-edit"></i> {{'platform.commands.manage' | translate}}
+                    </li>
+                    <li class="menu-item" ng-click='copyText(contextMenuEntity.id)'>
+                        <i class="menu-ico far fa-copy"></i> {{ 'stores.commands.copy-code' | translate }}
+                    </li>
+                    <li class="menu-item" ng-if="contextMenuEntity.url" ng-click='copyText(contextMenuEntity.url)'>
+                        <i class="menu-ico far fa-copy"></i> {{ 'stores.commands.copy-store-url' | translate }}
+                    </li>
+                    <li class="menu-item" ng-if="contextMenuEntity.url" ng-click='openStoreInNewWindow(contextMenuEntity)'>
+                        <i class="menu-ico fas fa-external-link-alt"></i> {{ 'stores.commands.open-in-new-window' | translate }}
                     </li>
                 </ul>
             </div>
@@ -37,5 +56,16 @@
 <script type="text/ng-template" id="list-actions.cell.html">
     <div class="ui-grid-actions" left-click-menu="grid.appScope.contextMenuEntity = row.entity" data-target="sto_menu">
         <i class="fa fa-ellipsis-v"></i>
+    </div>
+</script>
+<script type="text/ng-template" id="list-name.cell.html">
+    <div class="ui-grid-cell-contents">
+        <i class="table-ico fa fa-archive"></i>
+        <div class="inner-contents">
+            <div class="table-t">{{COL_FIELD}}</div>
+            <div class="table-descr" ng-if="row.entity.url">
+                <span class="store-url-label">{{row.entity.url}}</span>
+            </div>
+        </div>
     </div>
 </script>

--- a/tests/VirtoCommerce.StoreModule.Tests/StoreAssetPublicUrlResolverTests.cs
+++ b/tests/VirtoCommerce.StoreModule.Tests/StoreAssetPublicUrlResolverTests.cs
@@ -158,6 +158,63 @@ namespace VirtoCommerce.StoreModule.Tests
         }
 
         [Fact]
+        public void GetAbsoluteUrl_UrlAlreadyOnAssetHostWithBasePath_DoesNotDoubleBasePath()
+        {
+            //Arrange
+            var resolver = CreateResolver();
+            const string alreadyBased = "https://cdn.com/tenant1/assets/x.jpg";
+
+            //Act
+            var result = resolver.GetAbsoluteUrl(StoreWith("https://cdn.com/tenant1"), alreadyBased);
+
+            //Assert
+            result.Should().Be(alreadyBased);
+        }
+
+        [Fact]
+        public void GetAbsoluteUrl_IsIdempotent_ForRebasedUrl()
+        {
+            //Arrange
+            var resolver = CreateResolver();
+            var store = StoreWith("https://cdn.com/tenant1");
+
+            //Act
+            var once = resolver.GetAbsoluteUrl(store, "https://global.example.com/assets/x.jpg");
+            var twice = resolver.GetAbsoluteUrl(store, once);
+
+            //Assert
+            once.Should().Be("https://cdn.com/tenant1/assets/x.jpg");
+            twice.Should().Be(once);
+        }
+
+        [Fact]
+        public void GetAbsoluteUrl_ProtocolRelativeUrl_ReturnsAsIs()
+        {
+            //Arrange
+            var resolver = CreateResolver();
+            const string protocolRelative = "//cdn.example.com/img.jpg";
+
+            //Act
+            var result = resolver.GetAbsoluteUrl(StoreWith("https://cdn.store1.com"), protocolRelative);
+
+            //Assert
+            result.Should().Be(protocolRelative);
+        }
+
+        [Fact]
+        public void GetAbsoluteUrl_BaseUrlWithQueryOrFragment_AppendsRelativeToPath()
+        {
+            //Arrange
+            var resolver = CreateResolver();
+
+            //Act
+            var result = resolver.GetAbsoluteUrl(StoreWith("https://cdn.store1.com/assets?sig=abc#frag"), "catalog/x.jpg");
+
+            //Assert
+            result.Should().Be("https://cdn.store1.com/assets/catalog/x.jpg");
+        }
+
+        [Fact]
         public void GetAbsoluteUrl_InvalidStoreAssetUrl_AbsoluteUrl_ReturnsOriginal()
         {
             //Arrange

--- a/tests/VirtoCommerce.StoreModule.Tests/StoreAssetPublicUrlResolverTests.cs
+++ b/tests/VirtoCommerce.StoreModule.Tests/StoreAssetPublicUrlResolverTests.cs
@@ -1,0 +1,256 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using VirtoCommerce.StoreModule.Core;
+using VirtoCommerce.StoreModule.Core.Model;
+using VirtoCommerce.StoreModule.Data.Services;
+using Xunit;
+
+namespace VirtoCommerce.StoreModule.Tests
+{
+    public class StoreAssetPublicUrlResolverTests
+    {
+        private static StoreAssetPublicUrlResolver CreateResolver(string[] knownAssetHosts = null)
+        {
+            var options = Options.Create(new StoreAssetsOptions { KnownAssetHosts = knownAssetHosts ?? [] });
+            return new StoreAssetPublicUrlResolver(options, NullLogger<StoreAssetPublicUrlResolver>.Instance);
+        }
+
+        private static Store StoreWith(string assetPublicUrl) => new() { AssetPublicUrl = assetPublicUrl };
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void GetAbsoluteUrl_NullOrEmpty_ReturnsAsIs(string url)
+        {
+            //Arrange
+            var resolver = CreateResolver();
+
+            //Act
+            var result = resolver.GetAbsoluteUrl(StoreWith("https://cdn.store1.com"), url);
+
+            //Assert
+            result.Should().Be(url);
+        }
+
+        [Theory]
+        [InlineData("data:image/png;base64,iVBORw0KGgo=")]
+        [InlineData("blob:https://x/9b2c")]
+        public void GetAbsoluteUrl_DataOrBlobScheme_ReturnsAsIs(string url)
+        {
+            //Arrange
+            var resolver = CreateResolver();
+
+            //Act
+            var result = resolver.GetAbsoluteUrl(StoreWith("https://cdn.store1.com"), url);
+
+            //Assert
+            result.Should().Be(url);
+        }
+
+        [Theory]
+        [InlineData("catalog/x.jpg")]
+        [InlineData("https://global.example.com/assets/catalog/x.jpg")]
+        public void GetAbsoluteUrl_NoStoreAssetUrl_ReturnsAsIs(string url)
+        {
+            //Arrange
+            var resolver = CreateResolver();
+
+            //Act
+            var result = resolver.GetAbsoluteUrl(StoreWith(null), url);
+
+            //Assert
+            result.Should().Be(url);
+        }
+
+        [Fact]
+        public void GetAbsoluteUrl_NullStore_ThrowsArgumentNullException()
+        {
+            //Arrange
+            var resolver = CreateResolver();
+
+            //Act
+            var action = () => resolver.GetAbsoluteUrl(null, "catalog/x.jpg");
+
+            //Assert
+            action.Should().Throw<System.ArgumentNullException>();
+        }
+
+        [Theory]
+        [InlineData("catalog/x.jpg")]
+        [InlineData("/catalog/x.jpg")]
+        public void GetAbsoluteUrl_RelativeUrl_CombinesWithStoreAssetUrl(string url)
+        {
+            //Arrange
+            var resolver = CreateResolver();
+
+            //Act
+            var result = resolver.GetAbsoluteUrl(StoreWith("https://cdn.store1.com"), url);
+
+            //Assert
+            result.Should().Be("https://cdn.store1.com/catalog/x.jpg");
+        }
+
+        [Fact]
+        public void GetAbsoluteUrl_RelativeUrl_TrailingSlashBase_CombinesWithoutDoubleSlash()
+        {
+            //Arrange
+            var resolver = CreateResolver();
+
+            //Act
+            var result = resolver.GetAbsoluteUrl(StoreWith("https://cdn.store1.com/assets/"), "catalog/x.jpg");
+
+            //Assert
+            result.Should().Be("https://cdn.store1.com/assets/catalog/x.jpg");
+        }
+
+        [Fact]
+        public void GetAbsoluteUrl_AbsoluteUrl_NoKnownHosts_RebasesAnyHost()
+        {
+            //Arrange
+            var resolver = CreateResolver();
+
+            //Act
+            var result = resolver.GetAbsoluteUrl(StoreWith("https://cdn.store1.com"), "https://global.example.com/assets/catalog/x.jpg");
+
+            //Assert
+            result.Should().Be("https://cdn.store1.com/assets/catalog/x.jpg");
+        }
+
+        [Fact]
+        public void GetAbsoluteUrl_KnownHostsSet_ListedHost_IsRebased()
+        {
+            //Arrange
+            var resolver = CreateResolver(knownAssetHosts: ["global.example.com"]);
+
+            //Act
+            var result = resolver.GetAbsoluteUrl(StoreWith("https://cdn.store1.com"), "https://global.example.com/assets/catalog/x.jpg");
+
+            //Assert
+            result.Should().Be("https://cdn.store1.com/assets/catalog/x.jpg");
+        }
+
+        [Fact]
+        public void GetAbsoluteUrl_KnownHostsSet_UnlistedHost_ReturnsAsIs()
+        {
+            //Arrange
+            var resolver = CreateResolver(knownAssetHosts: ["global.example.com"]);
+            const string external = "https://external.com/img.jpg";
+
+            //Act
+            var result = resolver.GetAbsoluteUrl(StoreWith("https://cdn.store1.com"), external);
+
+            //Assert
+            result.Should().Be(external);
+        }
+
+        [Fact]
+        public void GetAbsoluteUrl_KnownHostsSet_AcceptsFullUrlEntries_CaseInsensitive()
+        {
+            //Arrange
+            var resolver = CreateResolver(knownAssetHosts: ["https://Global.Example.com/assets"]);
+
+            //Act
+            var result = resolver.GetAbsoluteUrl(StoreWith("https://cdn.store1.com"), "https://global.example.com/assets/catalog/x.jpg");
+
+            //Assert
+            result.Should().Be("https://cdn.store1.com/assets/catalog/x.jpg");
+        }
+
+        [Fact]
+        public void GetAbsoluteUrl_InvalidStoreAssetUrl_AbsoluteUrl_ReturnsOriginal()
+        {
+            //Arrange
+            var resolver = CreateResolver();
+            const string original = "https://global.example.com/assets/x.jpg";
+
+            //Act
+            var result = resolver.GetAbsoluteUrl(StoreWith("ht tp://not a valid base"), original);
+
+            //Assert
+            result.Should().Be(original);
+        }
+
+        [Fact]
+        public void GetAbsoluteUrl_KnownHostsSet_InvalidEntryIsIgnored_ValidEntryStillGates()
+        {
+            //Arrange
+            var resolver = CreateResolver(knownAssetHosts: ["not a valid host", "global.example.com"]);
+
+            //Act
+            var rebased = resolver.GetAbsoluteUrl(StoreWith("https://cdn.store1.com"), "https://global.example.com/assets/x.jpg");
+            var external = resolver.GetAbsoluteUrl(StoreWith("https://cdn.store1.com"), "https://external.com/x.jpg");
+
+            //Assert
+            rebased.Should().Be("https://cdn.store1.com/assets/x.jpg");
+            external.Should().Be("https://external.com/x.jpg");
+        }
+
+        [Fact]
+        public void GetAbsoluteUrl_KnownHostsSet_RelativeUrl_IsStillCombined()
+        {
+            //Arrange
+            var resolver = CreateResolver(knownAssetHosts: ["global.example.com"]);
+
+            //Act
+            var result = resolver.GetAbsoluteUrl(StoreWith("https://cdn.store1.com"), "catalog/x.jpg");
+
+            //Assert
+            result.Should().Be("https://cdn.store1.com/catalog/x.jpg");
+        }
+
+        [Fact]
+        public void GetAbsoluteUrl_BareHostStoreAssetUrl_NormalizesToHttps()
+        {
+            //Arrange
+            var resolver = CreateResolver();
+
+            //Act
+            var result = resolver.GetAbsoluteUrl(StoreWith("cdn.store1.com"), "https://global.example.com/assets/catalog/x.jpg");
+
+            //Assert
+            result.Should().Be("https://cdn.store1.com/assets/catalog/x.jpg");
+        }
+
+        [Fact]
+        public void GetAbsoluteUrl_StoreAssetUrlWithBasePath_PrependsPathOnRebase()
+        {
+            //Arrange
+            var resolver = CreateResolver();
+
+            //Act
+            var result = resolver.GetAbsoluteUrl(StoreWith("https://cdn.com/tenant1"), "https://global.example.com/assets/catalog/x.jpg");
+
+            //Assert
+            result.Should().Be("https://cdn.com/tenant1/assets/catalog/x.jpg");
+        }
+
+        [Fact]
+        public void GetAbsoluteUrl_AbsoluteUrlWithPort_RebasesToStoreDefaultPort()
+        {
+            //Arrange
+            var resolver = CreateResolver();
+
+            //Act
+            var result = resolver.GetAbsoluteUrl(StoreWith("https://cdn.store1.com"), "http://localhost:10645/assets/catalog/x.jpg");
+
+            //Assert
+            result.Should().Be("https://cdn.store1.com/assets/catalog/x.jpg");
+        }
+
+        [Theory]
+        [InlineData("https://global.example.com/assets/x.jpg?sas=abc#frag", "https://cdn.store1.com/assets/x.jpg?sas=abc#frag")]
+        [InlineData("catalog/x.jpg?sas=abc#frag", "https://cdn.store1.com/catalog/x.jpg?sas=abc#frag")]
+        public void GetAbsoluteUrl_PreservesQueryAndFragment(string url, string expected)
+        {
+            //Arrange
+            var resolver = CreateResolver();
+
+            //Act
+            var result = resolver.GetAbsoluteUrl(StoreWith("https://cdn.store1.com"), url);
+
+            //Assert
+            result.Should().Be(expected);
+        }
+    }
+}

--- a/tests/VirtoCommerce.StoreModule.Tests/VirtoCommerce.StoreModule.Tests.csproj
+++ b/tests/VirtoCommerce.StoreModule.Tests/VirtoCommerce.StoreModule.Tests.csproj
@@ -4,7 +4,7 @@
     <noWarn>1591;NU1608</noWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Description
feat: Configure per-store Asset Public URL for XAPI asset links

<img width="1101" height="742" alt="image" src="https://github.com/user-attachments/assets/060e3cea-7b9b-414e-800d-bddfa2884f38" />


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5089
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Store_3.1006.0-pr-171-e5e1.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Requires DB migrations and changes how public asset URLs are built for storefronts when configured; misconfigured `AssetPublicUrl` or `KnownAssetHosts` could break image links until corrected.
> 
> **Overview**
> Adds **per-store asset public URL** so Experience API consumers can rewrite image/asset links onto a store-specific CDN or domain instead of the global platform URL.
> 
> **Data & API surface:** New nullable `Store.AssetPublicUrl` on the domain model and `Store` table (migrations for SQL Server, MySQL, PostgreSQL), mapped through `StoreEntity` for CRUD/export-import.
> 
> **Resolution:** Introduces `IStoreAssetPublicUrlResolver` / `StoreAssetPublicUrlResolver` — when `AssetPublicUrl` is set, relative paths are joined to the base URL and absolute http(s) URLs are rebased (path, query, fragment preserved); `data:`, `blob:`, and protocol-relative URLs are left unchanged. Optional `VirtoCommerce:StoreAssets:KnownAssetHosts` limits which source hosts get rebased; empty list means rebase any absolute URL.
> 
> **Admin UI:** Store detail blade gains a **URLs** section with storefront URL and **Store asset URL** (with hint). Stores list adds state filter panel, shows URL under name, and context-menu actions to copy store id/URL and open storefront in a new tab. Locales updated across languages.
> 
> **Docs & tests:** README documents configuration and the new service; broad unit tests cover resolver edge cases. Minor EF/tooling package bumps on data provider projects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5e14f9aca8a40c3343145a6bdcdabf80295fb5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->