### PR TITLE
VCST-5490: use BackgroundJobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The rewrite of absolute URLs can be restricted to specific source hosts with the
 4. `StoreService` uses `StoreRepository` to load/persist `StoreEntity` objects through `StoreDbContext`.
 5. The appropriate database provider (SqlServer, MySql, or PostgreSql) handles migrations and EF Core configuration.
 6. After save, `StoreService` deep-saves store settings via `ISettingsManager` and publishes a `StoreChangedEvent`.
-7. `LogChangesChangedEventHandler` enqueues a Hangfire background job to record changes in the platform change log.
+7. `LogChangesChangedEventHandler` enqueues a background job (`LogEntityChangesJobHandler`) to record changes in the platform change log.
 8. `SendStoreUserVerificationEmailHandler` listens for `UserVerificationEmailEvent` and sends email verification via `StoreNotificationSender` when the user belongs to a store.
 9. Store and SEO data are cached via `StoreCacheRegion` and `StoreSeoInfoCacheRegion`, invalidated on changes.
 

--- a/src/VirtoCommerce.StoreModule.Core/VirtoCommerce.StoreModule.Core.csproj
+++ b/src/VirtoCommerce.StoreModule.Core/VirtoCommerce.StoreModule.Core.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1007.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1009.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1052.0" />
     <PackageReference Include="VirtoCommerce.Seo.Core" Version="3.1004.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.StoreModule.Data.MySql/VirtoCommerce.StoreModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.StoreModule.Data.MySql/VirtoCommerce.StoreModule.Data.MySql.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.StoreModule.Data\VirtoCommerce.StoreModule.Data.csproj" />

--- a/src/VirtoCommerce.StoreModule.Data.PostgreSql/VirtoCommerce.StoreModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.StoreModule.Data.PostgreSql/VirtoCommerce.StoreModule.Data.PostgreSql.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.StoreModule.Data\VirtoCommerce.StoreModule.Data.csproj" />

--- a/src/VirtoCommerce.StoreModule.Data.SqlServer/VirtoCommerce.StoreModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.StoreModule.Data.SqlServer/VirtoCommerce.StoreModule.Data.SqlServer.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.StoreModule.Data\VirtoCommerce.StoreModule.Data.csproj" />

--- a/src/VirtoCommerce.StoreModule.Data/Handlers/LogChangesChangedEventHandler.cs
+++ b/src/VirtoCommerce.StoreModule.Data/Handlers/LogChangesChangedEventHandler.cs
@@ -1,10 +1,12 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Hangfire;
 using VirtoCommerce.Platform.Core.ChangeLog;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.StoreModule.Core.Events;
+using VirtoCommerce.StoreModule.Data.Jobs;
 
 namespace VirtoCommerce.StoreModule.Data.Handlers
 {
@@ -19,17 +21,32 @@ namespace VirtoCommerce.StoreModule.Data.Handlers
 
         public virtual Task Handle(StoreChangedEvent @event)
         {
-            InnerHandle(@event);
-            return Task.CompletedTask;
+            return InnerHandle(@event);
         }
 
-        protected virtual void InnerHandle<T>(GenericChangedEntryEvent<T> @event) where T : IEntity
+        // Returns Task instead of void: enqueuing is asynchronous now. Breaking for an already-compiled override,
+        // which stops overriding the signature Handle calls and would be silently skipped.
+        protected virtual Task InnerHandle<T>(GenericChangedEntryEvent<T> @event) where T : IEntity
         {
             var logOperations = @event.ChangedEntries.Select(x => AbstractTypeFactory<OperationLog>.TryCreateInstance().FromChangedEntry(x)).ToArray();
-            //Background task is used here for performance reasons
-            BackgroundJob.Enqueue(() => LogEntityChangesInBackground(logOperations));
+
+            var payload = AbstractTypeFactory<LogEntityChangesJobPayload>.TryCreateInstance();
+            payload.OperationLogs = logOperations;
+
+            // Background task is used here for performance reasons.
+            // The static facade, not an injected IBackgroundJob: RegisterEventHandler resolves this handler once from
+            // the root provider and holds it for the process lifetime, so it must not capture a Scoped dependency.
+            return BackgroundJob.Enqueue<LogEntityChangesJobHandler>(payload);
         }
 
+        /// <summary>
+        /// Kept for background jobs enqueued by an earlier version, which reference this method by name.
+        /// New work goes through <see cref="LogEntityChangesJobHandler"/>; remove this once no such job
+        /// can still be pending.
+        /// </summary>
+        // Signature is byte-identical on purpose: Hangfire persists a queued job as type name + method name +
+        // parameter types + serialized args, so changing any of them would strand already-queued entries as Failed.
+        [Obsolete("Enqueued indirectly by legacy Hangfire jobs only; new work uses LogEntityChangesJobHandler.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
         public void LogEntityChangesInBackground(OperationLog[] operationLogs)
         {
             _changeLogService.SaveChangesAsync(operationLogs).GetAwaiter().GetResult();

--- a/src/VirtoCommerce.StoreModule.Data/Handlers/SendStoreUserVerificationEmailHandler.cs
+++ b/src/VirtoCommerce.StoreModule.Data/Handlers/SendStoreUserVerificationEmailHandler.cs
@@ -1,10 +1,12 @@
+using System;
 using System.Threading.Tasks;
-using Hangfire;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Core.Security.Events;
 using VirtoCommerce.StoreModule.Core.Services;
+using VirtoCommerce.StoreModule.Data.Jobs;
 
 namespace VirtoCommerce.StoreModule.Data.Handlers
 {
@@ -20,12 +22,23 @@ namespace VirtoCommerce.StoreModule.Data.Handlers
 
         public virtual Task Handle(UserVerificationEmailEvent message)
         {
-            BackgroundJob.Enqueue(() => SendUserEmailVerificationInBackground(message.ApplicationUser));
+            var payload = AbstractTypeFactory<SendUserEmailVerificationJobPayload>.TryCreateInstance();
+            payload.User = message.ApplicationUser;
 
-            return Task.CompletedTask;
+            // The static facade, not an injected IBackgroundJob: RegisterEventHandler resolves this handler once from
+            // the root provider and holds it for the process lifetime, so it must not capture a Scoped dependency.
+            return BackgroundJob.Enqueue<SendUserEmailVerificationJobHandler>(payload);
         }
 
 
+        /// <summary>
+        /// Kept for background jobs enqueued by an earlier version, which reference this method by name.
+        /// New work goes through <see cref="SendUserEmailVerificationJobHandler"/>; remove this once no such job
+        /// can still be pending.
+        /// </summary>
+        // Signature is byte-identical on purpose: Hangfire persists a queued job as type name + method name +
+        // parameter types + serialized args, so changing any of them would strand already-queued jobs as Failed.
+        [Obsolete("Enqueued indirectly by legacy Hangfire jobs only; new work uses SendUserEmailVerificationJobHandler.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
         public virtual async Task SendUserEmailVerificationInBackground(ApplicationUser user)
         {
             if (!user.StoreId.IsNullOrEmpty())

--- a/src/VirtoCommerce.StoreModule.Data/Jobs/LogEntityChangesJobHandler.cs
+++ b/src/VirtoCommerce.StoreModule.Data/Jobs/LogEntityChangesJobHandler.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.Platform.Core.ChangeLog;
+using VirtoCommerce.Platform.Core.Jobs;
+
+namespace VirtoCommerce.StoreModule.Data.Jobs
+{
+    /// <summary>
+    /// Persists the change-log entries collected by <see cref="Handlers.LogChangesChangedEventHandler"/>, off the request thread.
+    /// </summary>
+    /// <remarks>
+    /// Awaiting here is safe, unlike in the Hangfire method this replaces: the engine restores the enqueuing user into
+    /// the job's scope before Execute, and <c>IUserNameResolver</c> holds it in an AsyncLocal, which flows across
+    /// awaits - so <c>CreatedBy</c> on the written rows is the user who made the change, not the thread that resumed.
+    /// </remarks>
+    public class LogEntityChangesJobHandler(IChangeLogService changeLogService) : IBackgroundJobHandler<LogEntityChangesJobPayload>
+    {
+        public virtual Task Execute(LogEntityChangesJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return changeLogService.SaveChangesAsync(payload.OperationLogs);
+        }
+    }
+}

--- a/src/VirtoCommerce.StoreModule.Data/Jobs/LogEntityChangesJobPayload.cs
+++ b/src/VirtoCommerce.StoreModule.Data/Jobs/LogEntityChangesJobPayload.cs
@@ -1,0 +1,12 @@
+using VirtoCommerce.Platform.Core.ChangeLog;
+
+namespace VirtoCommerce.StoreModule.Data.Jobs
+{
+    /// <summary>
+    /// Payload of the background job that persists store change-log entries.
+    /// </summary>
+    public class LogEntityChangesJobPayload
+    {
+        public OperationLog[] OperationLogs { get; set; }
+    }
+}

--- a/src/VirtoCommerce.StoreModule.Data/Jobs/SendUserEmailVerificationJobHandler.cs
+++ b/src/VirtoCommerce.StoreModule.Data/Jobs/SendUserEmailVerificationJobHandler.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Jobs;
+using VirtoCommerce.StoreModule.Core.Services;
+
+namespace VirtoCommerce.StoreModule.Data.Jobs
+{
+    /// <summary>
+    /// Sends the store-branded email verification notification, off the request thread.
+    /// </summary>
+    public class SendUserEmailVerificationJobHandler(IStoreNotificationSender storeNotificationSender)
+        : IBackgroundJobHandler<SendUserEmailVerificationJobPayload>
+    {
+        public virtual async Task Execute(SendUserEmailVerificationJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            var user = payload.User;
+
+            if (!user.StoreId.IsNullOrEmpty())
+            {
+                await storeNotificationSender.SendUserEmailVerificationAsync(user);
+            }
+        }
+    }
+}

--- a/src/VirtoCommerce.StoreModule.Data/Jobs/SendUserEmailVerificationJobPayload.cs
+++ b/src/VirtoCommerce.StoreModule.Data/Jobs/SendUserEmailVerificationJobPayload.cs
@@ -1,0 +1,16 @@
+using VirtoCommerce.Platform.Core.Security;
+
+namespace VirtoCommerce.StoreModule.Data.Jobs
+{
+    /// <summary>
+    /// Payload of the background job that sends the store-branded email verification notification.
+    /// </summary>
+    public class SendUserEmailVerificationJobPayload
+    {
+        /// <summary>
+        /// The user to notify. Carried by value rather than by id, as the Hangfire job this replaces did: the event
+        /// fires with the user instance at hand, and re-reading it would race with whatever is still writing it.
+        /// </summary>
+        public ApplicationUser User { get; set; }
+    }
+}

--- a/src/VirtoCommerce.StoreModule.Data/VirtoCommerce.StoreModule.Data.csproj
+++ b/src/VirtoCommerce.StoreModule.Data/VirtoCommerce.StoreModule.Data.csproj
@@ -9,8 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="VirtoCommerce.CoreModule.Data" Version="3.1007.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.StoreModule.Core\VirtoCommerce.StoreModule.Core.csproj" />

--- a/src/VirtoCommerce.StoreModule.Web/Module.cs
+++ b/src/VirtoCommerce.StoreModule.Web/Module.cs
@@ -12,6 +12,7 @@ using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.DynamicProperties;
 using VirtoCommerce.Platform.Core.Events;
 using VirtoCommerce.Platform.Core.ExportImport;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Core.Security.Events;
@@ -28,6 +29,7 @@ using VirtoCommerce.StoreModule.Core.Security;
 using VirtoCommerce.StoreModule.Core.Services;
 using VirtoCommerce.StoreModule.Data.ExportImport;
 using VirtoCommerce.StoreModule.Data.Handlers;
+using VirtoCommerce.StoreModule.Data.Jobs;
 using VirtoCommerce.StoreModule.Data.MySql;
 using VirtoCommerce.StoreModule.Data.PostgreSql;
 using VirtoCommerce.StoreModule.Data.Repositories;
@@ -68,6 +70,12 @@ namespace VirtoCommerce.StoreModule.Web
 
             serviceCollection.AddTransient<LogChangesChangedEventHandler>();
             serviceCollection.AddTransient<SendStoreUserVerificationEmailHandler>();
+
+            // Neither is triggerable by name. The change-log job writes audit rows, and an OperationLog whose Id matches
+            // an existing row takes ChangeLogService.SaveChangesAsync's Patch branch; the verification job would let a
+            // caller-supplied payload send a store-branded email to any address.
+            serviceCollection.AddBackgroundJob<LogEntityChangesJobHandler, LogEntityChangesJobPayload>(triggerable: false);
+            serviceCollection.AddBackgroundJob<SendUserEmailVerificationJobHandler, SendUserEmailVerificationJobPayload>(triggerable: false);
             serviceCollection.AddTransient<IStoreNotificationSender, StoreNotificationSender>();
             serviceCollection.AddTransient<IStoreRepository, StoreRepository>();
             serviceCollection.AddTransient<Func<IStoreRepository>>(provider => () => provider.CreateScope().ServiceProvider.GetService<IStoreRepository>());

--- a/src/VirtoCommerce.StoreModule.Web/module.manifest
+++ b/src/VirtoCommerce.StoreModule.Web/module.manifest
@@ -4,8 +4,9 @@
   <version>3.1007.0</version>
   <version-tag />
 
-  <platformVersion>3.1039.0</platformVersion>
+  <platformVersion>3.1052.0</platformVersion>
   <dependencies>
+    <dependency id="VirtoCommerce.BackgroundJobs" version="3.1050.0" />
     <dependency id="VirtoCommerce.Core" version="3.1007.0" />
     <dependency id="VirtoCommerce.Notifications" version="3.1009.0" />
     <dependency id="VirtoCommerce.Seo" version="3.1004.0" />

--- a/src/VirtoCommerce.StoreModule.Web/module.manifest
+++ b/src/VirtoCommerce.StoreModule.Web/module.manifest
@@ -6,7 +6,6 @@
 
   <platformVersion>3.1052.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.BackgroundJobs" version="3.1050.0" />
     <dependency id="VirtoCommerce.Core" version="3.1007.0" />
     <dependency id="VirtoCommerce.Notifications" version="3.1009.0" />
     <dependency id="VirtoCommerce.Seo" version="3.1004.0" />

--- a/tests/VirtoCommerce.StoreModule.Tests/BackgroundJobEnqueueTests.cs
+++ b/tests/VirtoCommerce.StoreModule.Tests/BackgroundJobEnqueueTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using VirtoCommerce.Platform.Core.ChangeLog;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Jobs;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.Platform.Core.Security.Events;
+using VirtoCommerce.StoreModule.Core.Events;
+using VirtoCommerce.StoreModule.Core.Model;
+using VirtoCommerce.StoreModule.Core.Services;
+using VirtoCommerce.StoreModule.Data.Handlers;
+using VirtoCommerce.StoreModule.Data.Jobs;
+using Xunit;
+
+namespace VirtoCommerce.StoreModule.Tests
+{
+    // Any other test class that enqueues through the static BackgroundJob facade must join this collection:
+    // the facade has no reset API (Initialize rejects null), so Dispose leaves a DISPOSED provider behind in
+    // the static, and a class racing this one would see ObjectDisposedException from it.
+    [Collection(nameof(BackgroundJobEnqueueTests))]
+    public class BackgroundJobEnqueueTests
+    {
+        [Fact]
+        public async Task LogChanges_EnqueuesOneJobWithOneLogPerChangedEntry()
+        {
+            //Arrange
+            using var capture = new EnqueueCapture();
+            var handler = new LogChangesChangedEventHandler(Mock.Of<IChangeLogService>());
+
+            var message = new StoreChangedEvent(
+            [
+                new GenericChangedEntry<Store>(new Store { Id = "store1" }, new Store { Id = "store1" }, EntryState.Modified),
+                new GenericChangedEntry<Store>(new Store { Id = "store2" }, new Store { Id = "store2" }, EntryState.Added),
+            ]);
+
+            //Act
+            await handler.Handle(message);
+
+            //Assert
+            var payload = Assert.IsType<LogEntityChangesJobPayload>(capture.Payload);
+            Assert.Equal(1, capture.EnqueueCount);
+            Assert.Equal(["store1", "store2"], payload.OperationLogs.Select(x => x.ObjectId));
+            Assert.Equal([EntryState.Modified, EntryState.Added], payload.OperationLogs.Select(x => x.OperationType));
+        }
+
+        [Fact]
+        public async Task LogEntityChangesJobHandler_SavesThePayloadLogs()
+        {
+            //Arrange
+            var operationLogs = new[] { AbstractTypeFactory<OperationLog>.TryCreateInstance() };
+            var changeLogServiceMock = new Mock<IChangeLogService>();
+
+            var handler = new LogEntityChangesJobHandler(changeLogServiceMock.Object);
+
+            //Act
+            await handler.Execute(new LogEntityChangesJobPayload { OperationLogs = operationLogs }, context: null,
+                TestContext.Current.CancellationToken);
+
+            //Assert
+            changeLogServiceMock.Verify(x => x.SaveChangesAsync(operationLogs), Times.Once);
+        }
+
+        [Fact]
+        public async Task UserVerificationEmail_EnqueuesTheUserVerbatim()
+        {
+            //Arrange
+            using var capture = new EnqueueCapture();
+            var handler = new SendStoreUserVerificationEmailHandler(Mock.Of<IStoreNotificationSender>());
+
+            var user = new ApplicationUser { Id = "user1", StoreId = "store1" };
+
+            //Act
+            await handler.Handle(new UserVerificationEmailEvent(user));
+
+            //Assert
+            // The store check lives in the job, not the enqueue: the handler enqueues unconditionally, as before.
+            var payload = Assert.IsType<SendUserEmailVerificationJobPayload>(capture.Payload);
+            Assert.Equal(1, capture.EnqueueCount);
+            Assert.Same(user, payload.User);
+        }
+
+        [Fact]
+        public async Task SendUserEmailVerificationJobHandler_UserBelongsToStore_Sends()
+        {
+            //Arrange
+            var senderMock = new Mock<IStoreNotificationSender>();
+            var handler = new SendUserEmailVerificationJobHandler(senderMock.Object);
+
+            var user = new ApplicationUser { Id = "user1", StoreId = "store1" };
+
+            //Act
+            await handler.Execute(new SendUserEmailVerificationJobPayload { User = user }, context: null,
+                TestContext.Current.CancellationToken);
+
+            //Assert
+            senderMock.Verify(x => x.SendUserEmailVerificationAsync(user), Times.Once);
+        }
+
+        [Fact]
+        public async Task SendUserEmailVerificationJobHandler_UserWithoutStore_SendsNothing()
+        {
+            //Arrange
+            var senderMock = new Mock<IStoreNotificationSender>();
+            var handler = new SendUserEmailVerificationJobHandler(senderMock.Object);
+
+            var user = new ApplicationUser { Id = "user1" };
+
+            //Act
+            await handler.Execute(new SendUserEmailVerificationJobPayload { User = user }, context: null,
+                TestContext.Current.CancellationToken);
+
+            //Assert
+            senderMock.Verify(x => x.SendUserEmailVerificationAsync(It.IsAny<ApplicationUser>()), Times.Never);
+        }
+
+        // Captures what a handler enqueued through the static BackgroundJob facade. IBackgroundJob is registered
+        // Scoped here exactly as the engine module registers it, so this also proves the facade's per-call scope
+        // resolves it - the handlers themselves are root-resolved and must never hold it.
+        private sealed class EnqueueCapture : IDisposable
+        {
+            private readonly ServiceProvider _provider;
+
+            public EnqueueCapture()
+            {
+                BackgroundJobMock
+                    .Setup(x => x.Enqueue<LogEntityChangesJobHandler>(It.IsAny<object>(), It.IsAny<EnqueueOptions>(), It.IsAny<CancellationToken>()))
+                    .Callback<object, EnqueueOptions, CancellationToken>((payload, _, _) => Capture(payload))
+                    .ReturnsAsync("job-id");
+
+                BackgroundJobMock
+                    .Setup(x => x.Enqueue<SendUserEmailVerificationJobHandler>(It.IsAny<object>(), It.IsAny<EnqueueOptions>(), It.IsAny<CancellationToken>()))
+                    .Callback<object, EnqueueOptions, CancellationToken>((payload, _, _) => Capture(payload))
+                    .ReturnsAsync("job-id");
+
+                var services = new ServiceCollection();
+                services.AddScoped(_ => BackgroundJobMock.Object);
+                _provider = services.BuildServiceProvider(validateScopes: true);
+
+                BackgroundJob.Initialize(_provider);
+            }
+
+            public Mock<IBackgroundJob> BackgroundJobMock { get; } = new();
+
+            public object Payload { get; private set; }
+
+            public int EnqueueCount { get; private set; }
+
+            public void Dispose()
+            {
+                _provider.Dispose();
+            }
+
+            private void Capture(object payload)
+            {
+                Payload = payload;
+                EnqueueCount++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5490
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Store_3.1007.0-pr-174-26e4.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async audit logging and verification-email paths plus a platform version bump; legacy Hangfire entry points are preserved for in-flight jobs, and new jobs are registered non-triggerable to limit abuse.
> 
> **Overview**
> **Migrates store module background work** from Hangfire expression enqueues to the Virto Commerce platform job API (`BackgroundJob.Enqueue<THandler>(payload)`), aligned with **platform 3.1052.0** across Core, Data, DB providers, and `module.manifest`.
> 
> **Change logging:** `LogChangesChangedEventHandler` now enqueues `LogEntityChangesJobHandler` with `LogEntityChangesJobPayload` instead of `BackgroundJob.Enqueue(() => LogEntityChangesInBackground(...))`. `InnerHandle` is now `Task`-returning (a breaking change for subclasses that still override the old `void` signature). The old `LogEntityChangesInBackground` method remains **obsolete** with an unchanged signature so jobs already in the Hangfire queue can still run.
> 
> **Email verification:** `SendStoreUserVerificationEmailHandler` enqueues `SendUserEmailVerificationJobHandler` with the user on the payload; store-id filtering stays in the job handler. The legacy `SendUserEmailVerificationInBackground` method is likewise kept for queued jobs.
> 
> **DI:** `Module` registers both jobs via `AddBackgroundJob` with **`triggerable: false`** so they cannot be invoked by name from outside the event handlers. **`VirtoCommerce.Platform.Hangfire`** is removed from the Data project.
> 
> **Tests:** `BackgroundJobEnqueueTests` cover enqueue payloads and handler behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26e4cc815f1cc38f2defe351b1b22aa4acd1e97b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->